### PR TITLE
DSP-865: Fix API rc.17 breaking change + Update list name

### DIFF
--- a/knora/models/listnode.py
+++ b/knora/models/listnode.py
@@ -32,7 +32,7 @@ READ:
     * Access the information that has been provided to the instance
 
 UPDATE:
-    * Only partially implemented. Only "label" and "comment" attributes may be changed.
+    * "label", "comment", and "name" attributes may be changed.
     * You need an instance of an existing ListNode by reading an instance
     * Change the attributes by assigning the new values
     * Call the ``update```method on the instance
@@ -446,7 +446,7 @@ class ListNode:
         jsonobj = self.toJsonObj(Actions.Update, self.id)
         if jsonobj:
             jsondata = json.dumps(jsonobj, cls=SetEncoder)
-            result = self.con.put('/admin/lists/infos/' + quote_plus(self.id), jsondata)
+            result = self.con.put('/admin/lists/' + quote_plus(self.id), jsondata)
             return ListNode.fromJsonObj(self.con, result['listinfo'])
         else:
             return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,4 @@ requests
 jsonschema
 click
 rfc3987
-pprint
 pystrict


### PR DESCRIPTION
resolves [DSP-865](https://dasch.myjetbrains.com/youtrack/issue/DSP-865)
fix for breaking change in knora rc17:
- [x] fix the route used to update list node info
- [x] remove `pprint` from `requiremenets.txt` (`pprint` is part of the standard library, therefore cannot be present in requirements.txt.)
- [ ] update optional list name 
- [ ] labels and comments should be optional payload parameters of `updateListInfo` request