### PR TITLE
fix(xmlupload): legitimate html-escapes in utf8-texts don't raise a validation error any more (DEV-1936)

### DIFF
--- a/src/dsp_tools/utils/shared.py
+++ b/src/dsp_tools/utils/shared.py
@@ -135,16 +135,19 @@ def validate_xml_against_schema(input_file: Union[str, Path, etree._ElementTree[
             elem.tag = etree.QName(elem).localname
     
     # then: make the test
-    lines_with_illegal_xml_tags = list()
+    resources_with_illegal_xml_tags = list()
     for text in doc_without_namespace.findall(path="resource/text-prop/text"):
         if text.attrib["encoding"] == "utf8":
-            if regex.search(r'<([a-zA-Z/"]+|\S.*\S)>', str(text.text)) or len(list(text.iterchildren())) > 0:
-                lines_with_illegal_xml_tags.append(text.sourceline)
-    if lines_with_illegal_xml_tags:
-        logger.exception(f"XML-tags are not allowed in text properties with encoding=utf8. "
-                         f"The following lines of your XML file are affected: {lines_with_illegal_xml_tags}")
-        raise UserError(f"XML-tags are not allowed in text properties with encoding=utf8. "
-                        f"The following lines of your XML file are affected: {lines_with_illegal_xml_tags}")
+            if regex.search(r'<([a-zA-Z/"]+|[^\s0-9].*[^\s0-9])>', str(text.text)) or len(list(text.iterchildren())) > 0:
+                sourceline = f" line {text.sourceline}: " if text.sourceline else " "
+                propname = text.getparent().attrib["name"]
+                resname = text.getparent().getparent().attrib["id"]
+                resources_with_illegal_xml_tags.append(f" -{sourceline}resource '{resname}', property '{propname}'")
+    if resources_with_illegal_xml_tags:
+        err_msg = f"XML-tags are not allowed in text properties with encoding=utf8. The following resources of your XML file violate this rule:\n" 
+        err_msg += "\n".join(resources_with_illegal_xml_tags)
+        logger.exception(err_msg)
+        raise UserError(err_msg)
 
     logger.info("The XML file is syntactically correct and passed validation.")
     print("The XML file is syntactically correct and passed validation.")

--- a/src/dsp_tools/utils/shared.py
+++ b/src/dsp_tools/utils/shared.py
@@ -140,7 +140,7 @@ def _validate_xml_tags_in_text_properties(doc: etree._ElementTree[Any]) -> bool:
     Makes sure that there are no XML tags in simple texts.
     This can only be done with a regex, 
     because even if the simple text contains some XML tags, the simple text itself is not valid XML that could be parsed.
-    The extra challenge is that lxml transforms "pebble (&lt;2cm) and  boulder (&gt;20cm)" into "pebble (<2cm) and boulder (>20cm)" (but only if &gt; follows &lt;).
+    The extra challenge is that lxml transforms "pebble (&lt;2cm) and boulder (&gt;20cm)" into "pebble (<2cm) and boulder (>20cm)" (but only if &gt; follows &lt;).
     This forces us to write a regex that carefully distinguishes between a real tag (which is not allowed) and a false-positive-tag.
 
     Args:

--- a/src/dsp_tools/utils/shared.py
+++ b/src/dsp_tools/utils/shared.py
@@ -128,6 +128,30 @@ def validate_xml_against_schema(input_file: Union[str, Path, etree._ElementTree[
         raise UserError(error_msg)
     
     # make sure there are no XML tags in simple texts
+    _validate_xml_tags_in_text_properties(doc)    
+
+    logger.info("The XML file is syntactically correct and passed validation.")
+    print("The XML file is syntactically correct and passed validation.")
+    return True
+
+
+def _validate_xml_tags_in_text_properties(doc: etree._ElementTree[Any]) -> bool:
+    """
+    Makes sure that there are no XML tags in simple texts.
+    This can only be done with a regex, 
+    because even if the simple text contains some XML tags, the simple text itself is not valid XML that could be parsed.
+    The extra challenge is that lxml transforms "pebble (&lt;2cm) and  boulder (&gt;20cm)" into "pebble (<2cm) and boulder (>20cm)" (but only if &gt; follows &lt;).
+    This forces us to write a regex that carefully distinguishes between a real tag (which is not allowed) and a false-positive-tag.
+
+    Args:
+        doc: parsed XML file
+
+    Raises:
+        UserError: if there is an XML tag in one of the simple texts
+
+    Returns:
+        True if there are no XML tags in the simple texts
+    """
     # first: remove namespaces
     doc_without_namespace = copy.deepcopy(doc)
     for elem in doc_without_namespace.iter():
@@ -148,9 +172,7 @@ def validate_xml_against_schema(input_file: Union[str, Path, etree._ElementTree[
         err_msg += "\n".join(resources_with_illegal_xml_tags)
         logger.exception(err_msg)
         raise UserError(err_msg)
-
-    logger.info("The XML file is syntactically correct and passed validation.")
-    print("The XML file is syntactically correct and passed validation.")
+    
     return True
 
 

--- a/src/dsp_tools/utils/xml_upload.py
+++ b/src/dsp_tools/utils/xml_upload.py
@@ -318,7 +318,6 @@ def _parse_xml_file(input_file: Union[str, Path, etree._ElementTree[Any]]) -> et
     and transform the special tags <annotation>, <region>, and <link> 
     to their technically correct form 
     <resource restype="Annotation">, <resource restype="Region">, and <resource restype="LinkObj">.
-    If the input is already parsed, it won't be modified, but a copy of it will be returned.
 
     Args:
         input_file: path to the XML file, or parsed ElementTree

--- a/test/unittests/test_shared.py
+++ b/test/unittests/test_shared.py
@@ -32,6 +32,8 @@ class TestShared(unittest.TestCase):
         ):
             shared.validate_xml_against_schema(input_file="testdata/invalid-testdata/xml-data/utf8-text-with-xml-tags.xml")
 
+
+    def test_validate_xml_tags_in_text_properties(self) -> None:
         utf8_texts_with_allowed_html_escapes = [
             "(&lt;2cm) (&gt;10cm)",
             "text &lt; text/&gt;",
@@ -49,7 +51,7 @@ class TestShared(unittest.TestCase):
             for txt in utf8_texts_with_allowed_html_escapes
         ]
         for xml in utf8_texts_with_allowed_html_escapes:
-            self.assertTrue(shared.validate_xml_against_schema(input_file=etree.fromstring(xml)))
+            self.assertTrue(shared._validate_xml_tags_in_text_properties(doc=etree.fromstring(xml)))
 
         utf8_texts_with_forbidden_html_escapes = [
             f"&lt;tag s=\"t\"&gt;", 
@@ -65,7 +67,7 @@ class TestShared(unittest.TestCase):
         ]
         for xml in utf8_texts_with_forbidden_html_escapes:
             with self.assertRaisesRegex(UserError, "XML-tags are not allowed in text properties with encoding=utf8"):
-                shared.validate_xml_against_schema(input_file=etree.fromstring(xml))
+                shared._validate_xml_tags_in_text_properties(doc=etree.fromstring(xml))
 
 
 

--- a/testdata/xml-data/test-data-systematic.xml
+++ b/testdata/xml-data/test-data-systematic.xml
@@ -62,11 +62,13 @@
         <text-prop name=":hasSimpleText">
             <text encoding="utf8">&lt;</text>
             <text encoding="utf8">&amp;lt;</text>
-            <text encoding="utf8">(&lt;2cm) (&gt;10cm)</text>
+            <text encoding="utf8">text (&lt;2cm) text</text>
+            <text encoding="utf8">text (&lt;2cm) text (&gt;10cm) text</text>
+            <text encoding="utf8">Bei AU1026 handelt es sich um weissgrauen Sand mit einigen mittelgrossen (&lt;10cm) sowie auch wenigen grossen Kalkbruchsteinen (&gt;10cm), die zumeist scharfkantig sind.</text>
             <text encoding="utf8">&amp;</text>
             <text encoding="utf8">&amp;amp;</text>
             <!-- <text encoding="utf8">&lt;em&gt;text&lt;/em&gt;</text>
-            <text encoding="utf8">&lt;not a tag&gt;</text>  -->
+            <text encoding="utf8">&lt;tag s=\"t\"&gt;</text> -->
         </text-prop>
         <text-prop name=":hasTextArea">
             <text encoding="utf8">&lt;</text>
@@ -74,7 +76,7 @@
             <text encoding="utf8">&amp;</text>
             <text encoding="utf8">&amp;amp;</text>
             <!-- <text encoding="utf8">&lt;em&gt;text&lt;/em&gt;</text>
-            <text encoding="utf8">&lt;not a tag&gt;</text>  -->
+            <text encoding="utf8">&lt;tag s=\"t\"&gt;</text>  -->
         </text-prop>
         <text-prop name=":hasRichtext">
             <text encoding="xml">&lt;</text>

--- a/testdata/xml-data/test-data-systematic.xml
+++ b/testdata/xml-data/test-data-systematic.xml
@@ -62,6 +62,7 @@
         <text-prop name=":hasSimpleText">
             <text encoding="utf8">&lt;</text>
             <text encoding="utf8">&amp;lt;</text>
+            <text encoding="utf8">(&lt;2cm) (&gt;10cm)</text>
             <text encoding="utf8">&amp;</text>
             <text encoding="utf8">&amp;amp;</text>
             <!-- <text encoding="utf8">&lt;em&gt;text&lt;/em&gt;</text>


### PR DESCRIPTION
resolves DEV-1936