### PR TITLE
chore(start-stack): downgrade DSP-APP

### DIFF
--- a/src/dsp_tools/resources/start-stack/docker-compose.yml
+++ b/src/dsp_tools/resources/start-stack/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   app:
     # on the verge of every deployment (fortnightly), update the "image" value from the "app" value of
     # https://github.com/dasch-swiss/ops-deploy/blob/main/roles/dsp-deploy/files/RELEASE.json
-    image: daschswiss/dsp-app:v10.24.0
+    image: daschswiss/dsp-app:v10.23.7
     ports:
       - "4200:4200"
     networks:


### PR DESCRIPTION
According to the "DSP Releases" chat, they decided to use an older version of DSP-APP for today's deployment, because they detected a bug in the newer version.