### PR TITLE
refactor: use class Edge instead of complicated type annotation

### DIFF
--- a/src/dsp_tools/analyse_xml_data/construct_and_analyze_graph.py
+++ b/src/dsp_tools/analyse_xml_data/construct_and_analyze_graph.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-from collections import namedtuple
 from typing import Any
 
 import regex
 import rustworkx as rx
 from lxml import etree
 
-from dsp_tools.analyse_xml_data.models import Edge, ResptrLink, XMLLink
+from dsp_tools.analyse_xml_data.models import Cost, Edge, ResptrLink, XMLLink
 
 
 def create_info_from_xml_for_graph(
@@ -167,7 +166,6 @@ def _find_cheapest_outgoing_links(
     Returns:
         The edges (i.e. links) that should be stashed (containing all the edges connecting the two nodes)
     """
-    Cost = namedtuple("Cost", ["source", "target", "node_value", "edges_out"])
     costs: list[Cost] = []
     for source, target in cycle:
         edges_in = graph.in_edges(source)
@@ -175,7 +173,7 @@ def _find_cheapest_outgoing_links(
         edges_out = graph.out_edges(source)
         node_cost = sum(x[2].cost_links for x in edges_out)
         node_value = node_cost / node_gain
-        costs.append(Cost(source, target, node_value, edges_out))
+        costs.append(Cost(source, target, node_value))
     cheapest_cost = sorted(costs, key=lambda x: x.node_value)[0]
     cheapest_links = [
         x for x in edges if x.source_rx_index == cheapest_cost.source and x.target_rx_index == cheapest_cost.target

--- a/src/dsp_tools/analyse_xml_data/construct_and_analyze_graph.py
+++ b/src/dsp_tools/analyse_xml_data/construct_and_analyze_graph.py
@@ -175,9 +175,7 @@ def _find_cheapest_outgoing_links(
         node_value = node_cost / node_gain
         costs.append(Cost(source, target, node_value))
     cheapest_cost = sorted(costs, key=lambda x: x.node_value)[0]
-    cheapest_links = [
-        x for x in edges if x.source_rx_index == cheapest_cost.source and x.target_rx_index == cheapest_cost.target
-    ]
+    cheapest_links = [x for x in edges if x.source == cheapest_cost.source and x.target == cheapest_cost.target]
     return cheapest_links
 
 
@@ -196,12 +194,12 @@ def _remove_edges_to_stash(
         all_edges: all edges in the original graph
         remaining_nodes: indices of the nodes in the graph
     """
-    normal_edges_to_remove = [(x.source_rx_index, x.target_rx_index) for x in edges_to_remove]
+    normal_edges_to_remove = [(x.source, x.target) for x in edges_to_remove]
     # if only one (source, target) is removed, it removes only one edge, not all
     # therefore we need as many entries in the list as there are edges between the source and the target
 
     phantom_edges_to_remove = []
-    source, target = edges_to_remove[0].source_rx_index, edges_to_remove[0].target_rx_index
+    source, target = edges_to_remove[0].source, edges_to_remove[0].target
     for link_to_stash in [x.link_object for x in edges_to_remove]:
         if isinstance(link_to_stash, XMLLink):
             phantom_edges_to_remove.extend(
@@ -240,15 +238,15 @@ def _find_phantom_xml_edges(
     def check(x: Edge) -> bool:
         return all(
             (
-                x.source_rx_index == source_node_index,
-                x.target_rx_index != target_node_index,
+                x.source == source_node_index,
+                x.target != target_node_index,
                 x.link_object == xml_link_to_stash,
-                x.target_rx_index in remaining_nodes,
+                x.target in remaining_nodes,
                 # the target could have been removed because it was a leaf node, so we must check if it is still there
             )
         )
 
-    return [(x.source_rx_index, x.target_rx_index) for x in all_edges if check(x)]
+    return [(x.source, x.target) for x in all_edges if check(x)]
 
 
 def _add_stash_to_lookup_dict(

--- a/src/dsp_tools/analyse_xml_data/models.py
+++ b/src/dsp_tools/analyse_xml_data/models.py
@@ -65,3 +65,17 @@ class Edge:
     def as_tuple(self) -> tuple[int, int, ResptrLink | XMLLink]:
         """Returns a representation of this edge as a tuple of the source index, target index and link object"""
         return self.source_rx_index, self.target_rx_index, self.link_object
+
+
+@dataclass(frozen=True)
+class Cost:
+    """
+    Attributes:
+        source: rustworkx index of the resource from which the link originates
+        target: rustworkx index of the resource where the link points to
+        node_value: cost-gain-ratio if this link is stashed
+    """
+
+    source: int
+    target: int
+    node_value: float

--- a/src/dsp_tools/analyse_xml_data/models.py
+++ b/src/dsp_tools/analyse_xml_data/models.py
@@ -53,18 +53,18 @@ class Edge:
     This class represents an edge in the rustworkx graph.
 
     Attributes:
-        source_rx_index: rustworkx index of the resource from which the link originates
-        target_rx_index: rustworkx index of the resource where the link points to
+        source: rustworkx index of the resource from which the link originates
+        target: rustworkx index of the resource where the link points to
         link_object: the link that connects the source with the target
     """
 
-    source_rx_index: int
-    target_rx_index: int
+    source: int
+    target: int
     link_object: ResptrLink | XMLLink
 
     def as_tuple(self) -> tuple[int, int, ResptrLink | XMLLink]:
         """Returns a representation of this edge as a tuple of the source index, target index and link object"""
-        return self.source_rx_index, self.target_rx_index, self.link_object
+        return self.source, self.target, self.link_object
 
 
 @dataclass(frozen=True)

--- a/src/dsp_tools/analyse_xml_data/models.py
+++ b/src/dsp_tools/analyse_xml_data/models.py
@@ -9,7 +9,7 @@ class ResptrLink:
     """
     This class represents a direct link (resptr) between a starting resource and a target resource.
 
-    Args:
+    Attributes:
         source_id: ID of the resource from which the link originates
         target_id: ID of the resource where the link points to
         link_uuid: identifier of this link
@@ -31,7 +31,7 @@ class XMLLink:
     This class represents one or more links from a single starting resource to a set of target resources,
     where all target resources are linked to from a single text value of the starting resource.
 
-    Args:
+    Attributes:
         source_id: ID of the resource from which the link(s) originate
         target_ids: IDs of the resources that are referenced in the text value
         link_uuid: identifier of this link
@@ -45,3 +45,23 @@ class XMLLink:
     def cost_links(self) -> float:
         """The cost of this outgoing link (1 / number of links in the XML text)"""
         return 1 / len(self.target_ids)
+
+
+@dataclass(frozen=True)
+class Edge:
+    """
+    This class represents an edge in the rustworkx graph.
+
+    Attributes:
+        source_rx_index: rustworkx index of the resource from which the link originates
+        target_rx_index: rustworkx index of the resource where the link points to
+        link_object: the link that connects the source with the target
+    """
+
+    source_rx_index: int
+    target_rx_index: int
+    link_object: ResptrLink | XMLLink
+
+    def as_tuple(self) -> tuple[int, int, ResptrLink | XMLLink]:
+        """Returns a representation of this edge as a tuple of the source index, target index and link object"""
+        return self.source_rx_index, self.target_rx_index, self.link_object

--- a/test/unittests/test_analyse_xml_data/test_construct_and_analyze_graph.py
+++ b/test/unittests/test_analyse_xml_data/test_construct_and_analyze_graph.py
@@ -384,8 +384,7 @@ def test_remove_edges_to_stash_phantom_xml() -> None:
         Edge(2, 5, c_bdf_xml),
     ]
     graph.add_edges_from([e.as_tuple() for e in edges])
-    res_links_to_stash = _remove_edges_to_stash(graph, edges_to_remove, edges, remaining_nodes)
-    assert res_links_to_stash == [c_bdf_xml]
+    _remove_edges_to_stash(graph, edges_to_remove, edges, remaining_nodes)
     remaining_edges = list(graph.edge_list())
     expected_edges = [(0, 1), (0, 1), (0, 2), (0, 3), (0, 4), (1, 2), (1, 2), (1, 3), (3, 0), (3, 0), (3, 0)]
     assert unordered(remaining_edges) == expected_edges
@@ -411,10 +410,9 @@ def test_remove_edges_to_stash_several_resptr() -> None:
     graph.add_edges_from([e.as_tuple() for e in edges])
     edges_to_remove = edges[0:2]
     remaining_nodes = set(range(10))
-    res_links = _remove_edges_to_stash(graph, edges_to_remove, edges, remaining_nodes)
+    _remove_edges_to_stash(graph, edges_to_remove, edges, remaining_nodes)
     remaining_edges = list(graph.edge_list())
     assert unordered(remaining_edges) == [(1, 2), (1, 2), (1, 2), (1, 2), (1, 2), (2, 0), (2, 0), (2, 0), (2, 0)]
-    assert unordered(res_links) == [edges[0].link_object, edges[1].link_object]
 
 
 def test_remove_edges_to_stash_missing_nodes() -> None:
@@ -430,10 +428,9 @@ def test_remove_edges_to_stash_missing_nodes() -> None:
     graph.add_edges_from([e.as_tuple() for e in edges])
     remaining_nodes = {0, 1, 2}
     edges_to_remove = [Edge(0, 1, xml_link)]
-    res_links = _remove_edges_to_stash(graph, edges_to_remove, edges, remaining_nodes)
+    _remove_edges_to_stash(graph, edges_to_remove, edges, remaining_nodes)
     remaining_edges = list(graph.edge_list())
     assert unordered(remaining_edges) == [(1, 2), (2, 0)]
-    assert res_links == [xml_link]
 
 
 def test_find_phantom_xml_edges_no_remaining() -> None:

--- a/test/unittests/test_analyse_xml_data/test_construct_and_analyze_graph.py
+++ b/test/unittests/test_analyse_xml_data/test_construct_and_analyze_graph.py
@@ -214,14 +214,14 @@ def test_make_graph() -> None:
     xml = XMLLink("a", {"b", "c"})
     xml_links = [xml]
     all_ids = ["a", "b", "c"]
-    graph, rustworkx_index_to_id, edges = make_graph(resptr_links, xml_links, all_ids)
+    graph, node_to_id, edges = make_graph(resptr_links, xml_links, all_ids)
     assert graph.num_nodes() == 3
     assert graph.num_edges() == 3
-    assert rustworkx_index_to_id[0] == "a"
-    assert rustworkx_index_to_id[1] == "b"
-    assert rustworkx_index_to_id[2] == "c"
+    assert node_to_id[0] == "a"
+    assert node_to_id[1] == "b"
+    assert node_to_id[2] == "c"
     assert unordered(edges) == [Edge(0, 1, resptr), Edge(0, 1, xml), Edge(0, 2, xml)]
-    assert set(rustworkx_index_to_id.keys()) == {0, 1, 2}
+    assert set(node_to_id.keys()) == {0, 1, 2}
 
 
 def test_remove_leaf_nodes() -> None:

--- a/test/unittests/test_analyse_xml_data/test_construct_and_analyze_graph.py
+++ b/test/unittests/test_analyse_xml_data/test_construct_and_analyze_graph.py
@@ -21,7 +21,7 @@ from dsp_tools.analyse_xml_data.construct_and_analyze_graph import (
     generate_upload_order,
     make_graph,
 )
-from dsp_tools.analyse_xml_data.models import ResptrLink, XMLLink
+from dsp_tools.analyse_xml_data.models import Edge, ResptrLink, XMLLink
 
 
 def test_create_info_from_xml_for_graph_from_one_resource() -> None:
@@ -220,7 +220,7 @@ def test_make_graph() -> None:
     assert rustworkx_index_to_id[0] == "a"
     assert rustworkx_index_to_id[1] == "b"
     assert rustworkx_index_to_id[2] == "c"
-    assert unordered(edges) == [(0, 1, resptr), (0, 1, xml), (0, 2, xml)]
+    assert unordered(edges) == [Edge(0, 1, resptr), Edge(0, 1, xml), Edge(0, 2, xml)]
     assert set(rustworkx_index_to_id.keys()) == {0, 1, 2}
 
 
@@ -265,21 +265,21 @@ def test_find_cheapest_outgoing_links_one_resptr_link() -> None:
     graph: rx.PyDiGraph[Any, Any] = rx.PyDiGraph()
     graph.add_nodes_from(nodes)
     circle = [(0, 1), (1, 2), (2, 3), (3, 0)]
-    edges: list[tuple[int, int, XMLLink | ResptrLink]] = [
-        (0, 1, ResptrLink("", "")),
-        (0, 4, ResptrLink("", "")),
-        (0, 4, ResptrLink("", "")),
-        (1, 2, ResptrLink("", "")),
-        (1, 3, ResptrLink("", "")),
-        (2, 0, ResptrLink("", "")),
-        (2, 1, ResptrLink("", "")),
-        (2, 3, ResptrLink("", "")),
-        (3, 0, ResptrLink("", "")),
-        (3, 0, ResptrLink("", "")),
-        (3, 1, ResptrLink("", "")),
-        (3, 2, ResptrLink("", "")),
+    edges = [
+        Edge(0, 1, ResptrLink("", "")),
+        Edge(0, 4, ResptrLink("", "")),
+        Edge(0, 4, ResptrLink("", "")),
+        Edge(1, 2, ResptrLink("", "")),
+        Edge(1, 3, ResptrLink("", "")),
+        Edge(2, 0, ResptrLink("", "")),
+        Edge(2, 1, ResptrLink("", "")),
+        Edge(2, 3, ResptrLink("", "")),
+        Edge(3, 0, ResptrLink("", "")),
+        Edge(3, 0, ResptrLink("", "")),
+        Edge(3, 1, ResptrLink("", "")),
+        Edge(3, 2, ResptrLink("", "")),
     ]
-    graph.add_edges_from(edges)
+    graph.add_edges_from([e.as_tuple() for e in edges])
     cheapest_links = _find_cheapest_outgoing_links(graph, circle, edges)
     assert cheapest_links == [edges[3]]
 
@@ -296,26 +296,26 @@ def test_find_cheapest_outgoing_links_four_circle() -> None:
     ]
     graph: rx.PyDiGraph[Any, Any] = rx.PyDiGraph()
     graph.add_nodes_from(nodes)
-    edges: list[tuple[int, int, XMLLink | ResptrLink]] = [
-        (0, 1, ResptrLink("", "")),
-        (1, 0, ResptrLink("", "")),
-        (1, 2, ResptrLink("", "")),
-        (1, 2, ResptrLink("", "")),
-        (2, 3, ResptrLink("", "")),
-        (2, 3, ResptrLink("", "")),
-        (2, 3, ResptrLink("", "")),
-        (3, 0, ResptrLink("", "")),
-        (3, 0, ResptrLink("", "")),
-        (3, 5, ResptrLink("", "")),
-        (3, 5, ResptrLink("", "")),
-        (3, 5, ResptrLink("", "")),
-        (3, 5, ResptrLink("", "")),
-        (4, 2, ResptrLink("", "")),
-        (4, 2, ResptrLink("", "")),
-        (4, 2, ResptrLink("", "")),
-        (4, 2, ResptrLink("", "")),
+    edges = [
+        Edge(0, 1, ResptrLink("", "")),
+        Edge(1, 0, ResptrLink("", "")),
+        Edge(1, 2, ResptrLink("", "")),
+        Edge(1, 2, ResptrLink("", "")),
+        Edge(2, 3, ResptrLink("", "")),
+        Edge(2, 3, ResptrLink("", "")),
+        Edge(2, 3, ResptrLink("", "")),
+        Edge(3, 0, ResptrLink("", "")),
+        Edge(3, 0, ResptrLink("", "")),
+        Edge(3, 5, ResptrLink("", "")),
+        Edge(3, 5, ResptrLink("", "")),
+        Edge(3, 5, ResptrLink("", "")),
+        Edge(3, 5, ResptrLink("", "")),
+        Edge(4, 2, ResptrLink("", "")),
+        Edge(4, 2, ResptrLink("", "")),
+        Edge(4, 2, ResptrLink("", "")),
+        Edge(4, 2, ResptrLink("", "")),
     ]
-    graph.add_edges_from(edges)
+    graph.add_edges_from([e.as_tuple() for e in edges])
     circle = [(0, 1), (1, 2), (2, 3), (3, 0)]
     cheapest_links = _find_cheapest_outgoing_links(graph, circle, edges)
     assert cheapest_links == [edges[0]]
@@ -337,23 +337,23 @@ def test_find_cheapest_outgoing_links_xml() -> None:
     b_d_xml = XMLLink("1", {"3"})
     c_bdf_xml = XMLLink("2", {"1", "3", "5"})
     circle = [(0, 1), (1, 2), (2, 3), (3, 0)]
-    edges: list[tuple[int, int, XMLLink | ResptrLink]] = [
-        (0, 1, ResptrLink("", "")),
-        (0, 1, ResptrLink("", "")),
-        (0, 2, ResptrLink("", "")),
-        (1, 2, ResptrLink("", "")),
-        (1, 2, ResptrLink("", "")),
-        (3, 0, ResptrLink("", "")),
-        (3, 0, ResptrLink("", "")),
-        (3, 0, ResptrLink("", "")),
-        (1, 3, b_d_xml),
-        (2, 1, c_bdf_xml),
-        (2, 3, c_bdf_xml),
-        (2, 5, c_bdf_xml),
-        (0, 3, a_de_xml),
-        (0, 4, a_de_xml),
+    edges = [
+        Edge(0, 1, ResptrLink("", "")),
+        Edge(0, 1, ResptrLink("", "")),
+        Edge(0, 2, ResptrLink("", "")),
+        Edge(1, 2, ResptrLink("", "")),
+        Edge(1, 2, ResptrLink("", "")),
+        Edge(3, 0, ResptrLink("", "")),
+        Edge(3, 0, ResptrLink("", "")),
+        Edge(3, 0, ResptrLink("", "")),
+        Edge(1, 3, b_d_xml),
+        Edge(2, 1, c_bdf_xml),
+        Edge(2, 3, c_bdf_xml),
+        Edge(2, 5, c_bdf_xml),
+        Edge(0, 3, a_de_xml),
+        Edge(0, 4, a_de_xml),
     ]
-    graph.add_edges_from(edges)
+    graph.add_edges_from([e.as_tuple() for e in edges])
     cheapest_links = _find_cheapest_outgoing_links(graph, circle, edges)
     assert cheapest_links == [edges[10]]
 
@@ -365,25 +365,25 @@ def test_remove_edges_to_stash_phantom_xml() -> None:
     a_de_xml = XMLLink("0", {"3", "4"})
     b_d_xml = XMLLink("1", {"3"})
     c_bdf_xml = XMLLink("2", {"1", "3", "5"})
-    edges_to_remove: list[tuple[int, int, XMLLink | ResptrLink]] = [(2, 3, c_bdf_xml)]
+    edges_to_remove = [Edge(2, 3, c_bdf_xml)]
     remaining_nodes = set(range(10))
-    edges: list[tuple[int, int, XMLLink | ResptrLink]] = [
-        (0, 1, ResptrLink("", "")),
-        (0, 1, ResptrLink("", "")),
-        (0, 2, ResptrLink("", "")),
-        (1, 2, ResptrLink("", "")),
-        (1, 2, ResptrLink("", "")),
-        (3, 0, ResptrLink("", "")),
-        (3, 0, ResptrLink("", "")),
-        (3, 0, ResptrLink("", "")),
-        (0, 3, a_de_xml),
-        (0, 4, a_de_xml),
-        (1, 3, b_d_xml),
-        (2, 1, c_bdf_xml),
-        (2, 3, c_bdf_xml),
-        (2, 5, c_bdf_xml),
+    edges = [
+        Edge(0, 1, ResptrLink("", "")),
+        Edge(0, 1, ResptrLink("", "")),
+        Edge(0, 2, ResptrLink("", "")),
+        Edge(1, 2, ResptrLink("", "")),
+        Edge(1, 2, ResptrLink("", "")),
+        Edge(3, 0, ResptrLink("", "")),
+        Edge(3, 0, ResptrLink("", "")),
+        Edge(3, 0, ResptrLink("", "")),
+        Edge(0, 3, a_de_xml),
+        Edge(0, 4, a_de_xml),
+        Edge(1, 3, b_d_xml),
+        Edge(2, 1, c_bdf_xml),
+        Edge(2, 3, c_bdf_xml),
+        Edge(2, 5, c_bdf_xml),
     ]
-    graph.add_edges_from(edges)
+    graph.add_edges_from([e.as_tuple() for e in edges])
     res_links_to_stash = _remove_edges_to_stash(graph, edges_to_remove, edges, remaining_nodes)
     assert res_links_to_stash == [c_bdf_xml]
     remaining_edges = list(graph.edge_list())
@@ -395,26 +395,26 @@ def test_remove_edges_to_stash_several_resptr() -> None:
     nodes = ["0", "1", "2"]
     graph: rx.PyDiGraph[Any, Any] = rx.PyDiGraph()
     graph.add_nodes_from(nodes)
-    edges: list[tuple[int, int, XMLLink | ResptrLink]] = [
-        (0, 1, ResptrLink("", "")),
-        (0, 1, ResptrLink("", "")),
-        (1, 2, ResptrLink("", "")),
-        (1, 2, ResptrLink("", "")),
-        (1, 2, ResptrLink("", "")),
-        (1, 2, ResptrLink("", "")),
-        (1, 2, ResptrLink("", "")),
-        (2, 0, ResptrLink("", "")),
-        (2, 0, ResptrLink("", "")),
-        (2, 0, ResptrLink("", "")),
-        (2, 0, ResptrLink("", "")),
+    edges = [
+        Edge(0, 1, ResptrLink("", "")),
+        Edge(0, 1, ResptrLink("", "")),
+        Edge(1, 2, ResptrLink("", "")),
+        Edge(1, 2, ResptrLink("", "")),
+        Edge(1, 2, ResptrLink("", "")),
+        Edge(1, 2, ResptrLink("", "")),
+        Edge(1, 2, ResptrLink("", "")),
+        Edge(2, 0, ResptrLink("", "")),
+        Edge(2, 0, ResptrLink("", "")),
+        Edge(2, 0, ResptrLink("", "")),
+        Edge(2, 0, ResptrLink("", "")),
     ]
-    graph.add_edges_from(edges)
+    graph.add_edges_from([e.as_tuple() for e in edges])
     edges_to_remove = edges[0:2]
     remaining_nodes = set(range(10))
     res_links = _remove_edges_to_stash(graph, edges_to_remove, edges, remaining_nodes)
     remaining_edges = list(graph.edge_list())
     assert unordered(remaining_edges) == [(1, 2), (1, 2), (1, 2), (1, 2), (1, 2), (2, 0), (2, 0), (2, 0), (2, 0)]
-    assert unordered(res_links) == [edges[0][2], edges[1][2]]
+    assert unordered(res_links) == [edges[0].link_object, edges[1].link_object]
 
 
 def test_remove_edges_to_stash_missing_nodes() -> None:
@@ -422,14 +422,14 @@ def test_remove_edges_to_stash_missing_nodes() -> None:
     graph: rx.PyDiGraph[Any, Any] = rx.PyDiGraph()
     graph.add_nodes_from(nodes)
     xml_link = XMLLink("a", {"b", "d"})
-    edges: list[tuple[int, int, XMLLink | ResptrLink]] = [
-        (0, 1, xml_link),
-        (1, 2, ResptrLink("", "")),
-        (2, 0, ResptrLink("", "")),
+    edges = [
+        Edge(0, 1, xml_link),
+        Edge(1, 2, ResptrLink("", "")),
+        Edge(2, 0, ResptrLink("", "")),
     ]
-    graph.add_edges_from(edges)
+    graph.add_edges_from([e.as_tuple() for e in edges])
     remaining_nodes = {0, 1, 2}
-    edges_to_remove: list[tuple[int, int, XMLLink | ResptrLink]] = [(0, 1, xml_link)]
+    edges_to_remove = [Edge(0, 1, xml_link)]
     res_links = _remove_edges_to_stash(graph, edges_to_remove, edges, remaining_nodes)
     remaining_edges = list(graph.edge_list())
     assert unordered(remaining_edges) == [(1, 2), (2, 0)]
@@ -438,10 +438,10 @@ def test_remove_edges_to_stash_missing_nodes() -> None:
 
 def test_find_phantom_xml_edges_no_remaining() -> None:
     xml_link = XMLLink("0", {"2", "3"})
-    edges: list[tuple[int, int, XMLLink | ResptrLink]] = [
-        (0, 1, xml_link),
-        (1, 2, ResptrLink("", "")),
-        (2, 0, ResptrLink("", "")),
+    edges = [
+        Edge(0, 1, xml_link),
+        Edge(1, 2, ResptrLink("", "")),
+        Edge(2, 0, ResptrLink("", "")),
     ]
     remaining_nodes = {0, 1, 2}
     phantoms = _find_phantom_xml_edges(0, 1, edges, xml_link, remaining_nodes)
@@ -450,11 +450,11 @@ def test_find_phantom_xml_edges_no_remaining() -> None:
 
 def test_find_phantom_xml_edges_one_link() -> None:
     xml_link = XMLLink("0", {"1", "3"})
-    edges: list[tuple[int, int, XMLLink | ResptrLink]] = [
-        (0, 1, xml_link),
-        (0, 3, xml_link),
-        (1, 2, ResptrLink("", "")),
-        (2, 0, ResptrLink("", "")),
+    edges = [
+        Edge(0, 1, xml_link),
+        Edge(0, 3, xml_link),
+        Edge(1, 2, ResptrLink("", "")),
+        Edge(2, 0, ResptrLink("", "")),
     ]
     remaining_nodes = {0, 1, 2, 3}
     phantoms = _find_phantom_xml_edges(0, 1, edges, xml_link, remaining_nodes)
@@ -488,18 +488,18 @@ def test_generate_upload_order_with_stash() -> None:
     node_idx = set(graph.add_nodes_from(nodes))
     node_idx_lookup = dict(zip(node_idx, nodes))
     abf_xml = XMLLink("0", {"1", "5"})
-    edges: list[tuple[int, int, XMLLink | ResptrLink]] = [
-        (1, 2, ResptrLink("", "")),
-        (2, 3, ResptrLink("", "")),
-        (3, 0, ResptrLink("", "")),
-        (3, 0, ResptrLink("", "")),
-        (3, 0, ResptrLink("", "")),
-        (3, 4, ResptrLink("", "")),
-        (5, 6, ResptrLink("", "")),
-        (0, 1, abf_xml),
-        (0, 5, abf_xml),
+    edges = [
+        Edge(1, 2, ResptrLink("", "")),
+        Edge(2, 3, ResptrLink("", "")),
+        Edge(3, 0, ResptrLink("", "")),
+        Edge(3, 0, ResptrLink("", "")),
+        Edge(3, 0, ResptrLink("", "")),
+        Edge(3, 4, ResptrLink("", "")),
+        Edge(5, 6, ResptrLink("", "")),
+        Edge(0, 1, abf_xml),
+        Edge(0, 5, abf_xml),
     ]
-    graph.add_edges_from(edges)
+    graph.add_edges_from([e.as_tuple() for e in edges])
     stash_lookup, upload_order, stash_counter = generate_upload_order(graph, node_idx_lookup, edges)
     expected_stash_lookup = {"0": [abf_xml.link_uuid]}
     assert stash_counter == 1
@@ -516,12 +516,12 @@ def test_generate_upload_order_no_stash() -> None:
     nodes = ["0", "1", "2", "3"]
     node_idx = set(graph.add_nodes_from(nodes))
     node_idx_lookup = dict(zip(node_idx, nodes))
-    edges: list[tuple[int, int, XMLLink | ResptrLink]] = [
-        (0, 1, ResptrLink("", "")),
-        (1, 2, ResptrLink("", "")),
-        (2, 3, ResptrLink("", "")),
+    edges = [
+        Edge(0, 1, ResptrLink("", "")),
+        Edge(1, 2, ResptrLink("", "")),
+        Edge(2, 3, ResptrLink("", "")),
     ]
-    graph.add_edges_from(edges)
+    graph.add_edges_from([e.as_tuple() for e in edges])
     stash_lookup, upload_order, stash_counter = generate_upload_order(graph, node_idx_lookup, edges)
     assert stash_lookup == dict()
     assert stash_counter == 0
@@ -535,26 +535,26 @@ def test_generate_upload_order_two_circles() -> None:
     nodes = ["0", "1", "2", "3", "4", "5", "6"]
     node_idx = set(graph.add_nodes_from(nodes))
     node_idx_lookup = dict(zip(node_idx, nodes))
-    edges: list[tuple[int, int, XMLLink | ResptrLink]] = [
-        (0, 1, ResptrLink("0", "1")),
-        (0, 5, ResptrLink("0", "5")),
-        (1, 2, ResptrLink("1", "2")),
-        (2, 3, ResptrLink("2", "3")),
-        (2, 0, ResptrLink("2", "0")),
-        (3, 0, ResptrLink("3", "0")),
-        (3, 0, ResptrLink("3", "0")),
-        (3, 0, ResptrLink("3", "0")),
-        (3, 4, ResptrLink("3", "4")),
-        (5, 6, ResptrLink("5", "6")),
-        (5, 6, ResptrLink("5", "6")),
-        (6, 5, ResptrLink("6", "5")),
-        (6, 5, ResptrLink("6", "5")),
-        (6, 5, ResptrLink("6", "5")),
+    edges = [
+        Edge(0, 1, ResptrLink("0", "1")),
+        Edge(0, 5, ResptrLink("0", "5")),
+        Edge(1, 2, ResptrLink("1", "2")),
+        Edge(2, 3, ResptrLink("2", "3")),
+        Edge(2, 0, ResptrLink("2", "0")),
+        Edge(3, 0, ResptrLink("3", "0")),
+        Edge(3, 0, ResptrLink("3", "0")),
+        Edge(3, 0, ResptrLink("3", "0")),
+        Edge(3, 4, ResptrLink("3", "4")),
+        Edge(5, 6, ResptrLink("5", "6")),
+        Edge(5, 6, ResptrLink("5", "6")),
+        Edge(6, 5, ResptrLink("6", "5")),
+        Edge(6, 5, ResptrLink("6", "5")),
+        Edge(6, 5, ResptrLink("6", "5")),
     ]
-    graph.add_edges_from(edges)
+    graph.add_edges_from([e.as_tuple() for e in edges])
     stash_lookup, upload_order, stash_counter = generate_upload_order(graph, node_idx_lookup, edges)
     circles = ["0", "1", "2", "3", "5", "6"]
-    expected_stash = {"0": [edges[0][2].link_uuid], "5": [x[2].link_uuid for x in edges[9:11]]}
+    expected_stash = {"0": [edges[0].link_object.link_uuid], "5": [x.link_object.link_uuid for x in edges[9:11]]}
     assert upload_order[0] == "4"
     assert unordered(upload_order[1:]) == circles
     assert stash_counter == 3

--- a/testdata/xml-data/circular-references/analyse_circles_in_xml.py
+++ b/testdata/xml-data/circular-references/analyse_circles_in_xml.py
@@ -37,8 +37,8 @@ def analyse_circles_in_data(xml_filepath: Path, tracer_output_file: str, save_tr
     print(f"Total Number of resptr Links: {len(resptr_links)}")
     print(f"Total Number of XML Texts with Links: {len(xml_links)}")
     print("=" * 80)
-    graph, rustworkx_index_to_id, edges = make_graph(resptr_links, xml_links, all_resource_ids)
-    _, _, stash_counter = generate_upload_order(graph, rustworkx_index_to_id, edges)
+    graph, node_to_id, edges = make_graph(resptr_links, xml_links, all_resource_ids)
+    _, _, stash_counter = generate_upload_order(graph, node_to_id, edges)
     print("Number of Links Stashed:", stash_counter)
     tracer.stop()
     if save_tracer:


### PR DESCRIPTION
The complicated type annotation `list[tuple[int, int, XMLLink | ResptrLink]]` is replaced by a new model: `class Edge` in `models.py`