### PR TITLE
chore: avoid mutable default values in class attributes (DEV-3234)

### DIFF
--- a/src/dsp_tools/commands/id2iri.py
+++ b/src/dsp_tools/commands/id2iri.py
@@ -1,5 +1,6 @@
 import copy
 import json
+from collections.abc import Mapping
 from datetime import datetime
 from pathlib import Path
 
@@ -61,7 +62,7 @@ def _parse_json_file(json_file: Path) -> dict[str, str]:
 
 def _replace_resptrs(
     tree: etree._Element,
-    mapping: dict[str, str],
+    mapping: Mapping[str, str],
     used_mapping_entries: set[str],
 ) -> tuple[etree._Element, set[str]]:
     """
@@ -94,7 +95,7 @@ def _replace_resptrs(
 
 def _replace_salsah_links(
     tree: etree._Element,
-    mapping: dict[str, str],
+    mapping: Mapping[str, str],
     used_mapping_entries: set[str],
 ) -> tuple[etree._Element, set[str]]:
     """
@@ -127,7 +128,7 @@ def _replace_salsah_links(
 
 def _replace_ids_by_iris(
     tree: etree._Element,
-    mapping: dict[str, str],
+    mapping: Mapping[str, str],
 ) -> etree._Element:
     """
     Iterate over the <resptr> tags and the salsah-links of the <text> tags,
@@ -163,7 +164,7 @@ def _replace_ids_by_iris(
 
 def _remove_resources_if_id_in_mapping(
     tree: etree._Element,
-    mapping: dict[str, str],
+    mapping: Mapping[str, str],
 ) -> etree._Element:
     """
     Remove all resources from the XML file if their ID is in the mapping.

--- a/test/fast_xmlupload/test_fast_xmlupload.py
+++ b/test/fast_xmlupload/test_fast_xmlupload.py
@@ -1,7 +1,6 @@
 import shutil
 import unittest
 from pathlib import Path
-from typing import ClassVar
 
 import pytest
 
@@ -27,7 +26,7 @@ class TestFastXmlUpload(unittest.TestCase):
     output_dir = "testdata/preprocessed_files"
     xml_file = "testdata/xml-data/test-data-fast-xmlupload.xml"
     json_file = "testdata/json-project/test-project-fast-xmlupload.json"
-    txt_files: ClassVar = ["processed_files.txt", "unprocessed_files.txt"]
+    txt_files = ("processed_files.txt", "unprocessed_files.txt")
 
     @classmethod
     def setUpClass(cls) -> None:

--- a/test/unittests/commands/test_id2iri.py
+++ b/test/unittests/commands/test_id2iri.py
@@ -1,7 +1,7 @@
 import shutil
 import unittest
 from pathlib import Path
-from typing import ClassVar
+from types import MappingProxyType
 
 import pytest
 import regex
@@ -16,12 +16,14 @@ from dsp_tools.models.exceptions import BaseError
 
 class TestIdToIri(unittest.TestCase):
     tmp_dir = Path("testdata/tmp")
-    mapping: ClassVar = {
-        "test_thing_0": "http://rdfh.ch/082E/-lRvrg7tQI6aVpcTJbVrwg",
-        "test_thing_1": "http://rdfh.ch/082E/JK63OpYWTDWNYVOYFN7FdQ",
-        "test_thing_2": "http://rdfh.ch/082E/1l63Oasdfopiujlkmn78ak",
-        "test_thing_with_ark_1": "http://rdfh.ch/082E/qwasddoiu8_6flkjh67dss",
-    }
+    mapping = MappingProxyType(
+        {
+            "test_thing_0": "http://rdfh.ch/082E/-lRvrg7tQI6aVpcTJbVrwg",
+            "test_thing_1": "http://rdfh.ch/082E/JK63OpYWTDWNYVOYFN7FdQ",
+            "test_thing_2": "http://rdfh.ch/082E/1l63Oasdfopiujlkmn78ak",
+            "test_thing_with_ark_1": "http://rdfh.ch/082E/qwasddoiu8_6flkjh67dss",
+        }
+    )
 
     @classmethod
     def setUpClass(cls) -> None:

--- a/test/unittests/commands/xmlupload/test_check_consistency_with_ontology_high_level.py
+++ b/test/unittests/commands/xmlupload/test_check_consistency_with_ontology_high_level.py
@@ -24,7 +24,7 @@ class ConnectionMockRaising(ConnectionMockBase):
 
 @dataclass
 class ConnectionMockWithResponses(ConnectionMockBase):
-    get_responses: tuple[dict[str, Any]] = (  # type: ignore[assignment]
+    get_responses: tuple[dict[str, Any], ...] = (
         {
             "project": {
                 "ontologies": ["/testonto"],

--- a/test/unittests/commands/xmlupload/test_check_consistency_with_ontology_high_level.py
+++ b/test/unittests/commands/xmlupload/test_check_consistency_with_ontology_high_level.py
@@ -2,7 +2,7 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 from test.unittests.commands.xmlupload.connection_mock import ConnectionMockBase
-from typing import Any, ClassVar
+from typing import Any
 
 import pytest
 from lxml import etree
@@ -24,7 +24,7 @@ class ConnectionMockRaising(ConnectionMockBase):
 
 @dataclass
 class ConnectionMockWithResponses(ConnectionMockBase):
-    get_responses: ClassVar[list[dict[str, Any]]] = [
+    get_responses: tuple[dict[str, Any]] = (  # type: ignore[assignment]
         {
             "project": {
                 "ontologies": ["/testonto"],
@@ -46,14 +46,17 @@ class ConnectionMockWithResponses(ConnectionMockBase):
                 }
             ]
         },
-    ]
+    )
+    counter = 0
 
     def get(
         self,
         route: str,  # noqa: ARG002 (unused-method-argument)
         headers: dict[str, str] | None = None,  # noqa: ARG002 (unused-method-argument)
     ) -> dict[str, Any]:
-        return self.get_responses.pop(0)
+        response = self.get_responses[self.counter]
+        self.counter += 1
+        return response
 
 
 def test_error_on_nonexistent_shortcode() -> None:


### PR DESCRIPTION
In some places, dsp-tools uses defaults for mutable class attributes, which is a bad idea: https://docs.astral.sh/ruff/rules/mutable-class-default/