### PR TITLE
chore: renaming functions of ontology checks in xmlupload

### DIFF
--- a/src/dsp_tools/commands/xmlupload/models/ontology_lookup_models.py
+++ b/src/dsp_tools/commands/xmlupload/models/ontology_lookup_models.py
@@ -18,39 +18,39 @@ class ProjectOntosInformation:
     onto_lookup: dict[str, OntoInfo]
 
 
-def extract_classes_properties_from_onto(onto_graph: list[dict[str, Any]]) -> OntoInfo:
+def extract_classes_properties_from_onto(onto_json: list[dict[str, Any]]) -> OntoInfo:
     """
     This function takes an ontology graph from the DSP-API.
     It extracts the classes and properties.
     And saves them in an instance of the class Ontology.
 
     Args:
-        onto_graph: graph from DSP-API
+        onto_json: graph from DSP-API
 
     Returns:
         Ontology instance with the classes and properties
     """
-    classes = _get_all_cleaned_classes_from_graph(onto_graph)
-    properties = _get_all_cleaned_properties_from_graph(onto_graph)
+    classes = _get_all_cleaned_classes_from_json(onto_json)
+    properties = _get_all_cleaned_properties_from_json(onto_json)
     return OntoInfo(classes, properties)
 
 
-def _get_all_cleaned_classes_from_graph(onto_graph: list[dict[str, Any]]) -> list[str]:
-    classes = _get_all_classes_from_graph(onto_graph)
+def _get_all_cleaned_classes_from_json(onto_json: list[dict[str, Any]]) -> list[str]:
+    classes = _get_all_classes_from_json(onto_json)
     return _remove_prefixes(classes)
 
 
-def _get_all_classes_from_graph(onto_graph: list[dict[str, Any]]) -> list[str]:
-    return [elem["@id"] for elem in onto_graph if elem.get("knora-api:isResourceClass")]
+def _get_all_classes_from_json(onto_json: list[dict[str, Any]]) -> list[str]:
+    return [elem["@id"] for elem in onto_json if elem.get("knora-api:isResourceClass")]
 
 
-def _get_all_cleaned_properties_from_graph(onto_graph: list[dict[str, Any]]) -> list[str]:
-    props = _get_all_properties_from_graph(onto_graph)
+def _get_all_cleaned_properties_from_json(onto_json: list[dict[str, Any]]) -> list[str]:
+    props = _get_all_properties_from_json(onto_json)
     return _remove_prefixes(props)
 
 
-def _get_all_properties_from_graph(onto_graph: list[dict[str, Any]]) -> list[str]:
-    return [elem["@id"] for elem in onto_graph if not elem.get("knora-api:isResourceClass")]
+def _get_all_properties_from_json(onto_json: list[dict[str, Any]]) -> list[str]:
+    return [elem["@id"] for elem in onto_json if not elem.get("knora-api:isResourceClass")]
 
 
 def _remove_prefixes(ontology_elements: list[str]) -> list[str]:

--- a/src/dsp_tools/commands/xmlupload/xmlupload.py
+++ b/src/dsp_tools/commands/xmlupload/xmlupload.py
@@ -65,6 +65,7 @@ def xmlupload(
     Raises:
         BaseError: in case of permanent network or software failure
         UserError: in case of permanent network or software failure, or if the XML file is invalid
+        InputError: in case of permanent network or software failure, or if the XML file is invalid
 
     Returns:
         True if all resources could be uploaded without errors; False if one of the resources could not be

--- a/test/unittests/commands/xmlupload/test_check_consistency_with_ontology_high_level.py
+++ b/test/unittests/commands/xmlupload/test_check_consistency_with_ontology_high_level.py
@@ -8,7 +8,7 @@ from lxml import etree
 
 from dsp_tools.commands.xmlupload.check_consistency_with_ontology import do_xml_consistency_check_with_ontology
 from dsp_tools.commands.xmlupload.ontology_client import OntologyClientLive
-from dsp_tools.models.exceptions import BaseError, UserError
+from dsp_tools.models.exceptions import BaseError, InputError, UserError
 
 
 @dataclass
@@ -95,7 +95,7 @@ def test_error_on_nonexistent_onto_name() -> None:
         "    - the_only_resource\n\n"
         "---------------------------------------\n\n"
     )
-    with pytest.raises(UserError, match=expected):
+    with pytest.raises(InputError, match=expected):
         do_xml_consistency_check_with_ontology(ontology_client, root)
 
 

--- a/test/unittests/commands/xmlupload/test_check_consistency_with_ontology_low_level.py
+++ b/test/unittests/commands/xmlupload/test_check_consistency_with_ontology_low_level.py
@@ -3,11 +3,11 @@ from lxml import etree
 from pytest_unordered import unordered
 
 from dsp_tools.commands.xmlupload.check_consistency_with_ontology import (
-    _check_if_all_class_types_exist,
-    _check_if_all_properties_exist,
-    _check_if_one_class_type_exists,
-    _check_if_one_property_exists,
-    _find_if_all_classes_and_properties_exist_in_onto,
+    _check_all_class_types_exist,
+    _check_all_properties_exist,
+    _check_one_class_type_exists,
+    _check_one_property_exists,
+    _find_all_classes_and_properties_exist_in_onto,
     _get_all_class_types_and_ids_from_data,
     _get_all_classes_and_properties_from_data,
     _get_all_property_names_and_resource_ids_one_resource,
@@ -26,7 +26,7 @@ class TestCheckClassType:
                 "knora-api": OntoInfo(classes=["knoraClassA"], properties=[]),
             },
         )
-        assert not _check_if_one_class_type_exists("knoraClassA", onto_check_info)
+        assert not _check_one_class_type_exists("knoraClassA", onto_check_info)
 
     def test_knora_prefix(self) -> None:
         onto_check_info = ProjectOntosInformation(
@@ -36,7 +36,7 @@ class TestCheckClassType:
                 "knora-api": OntoInfo(classes=["knoraClassA"], properties=[]),
             },
         )
-        assert not _check_if_one_class_type_exists("knora-api:knoraClassA", onto_check_info)
+        assert not _check_one_class_type_exists("knora-api:knoraClassA", onto_check_info)
 
     def test_no_default_prefix(self) -> None:
         onto_check_info = ProjectOntosInformation(
@@ -46,7 +46,7 @@ class TestCheckClassType:
                 "knora-api": OntoInfo(classes=["knoraClassA"], properties=[]),
             },
         )
-        assert not _check_if_one_class_type_exists(":classA", onto_check_info)
+        assert not _check_one_class_type_exists(":classA", onto_check_info)
 
     def test_default_prefix(self) -> None:
         onto_check_info = ProjectOntosInformation(
@@ -56,7 +56,7 @@ class TestCheckClassType:
                 "knora-api": OntoInfo(classes=["knoraClassA"], properties=[]),
             },
         )
-        assert not _check_if_one_class_type_exists("test:classB", onto_check_info)
+        assert not _check_one_class_type_exists("test:classB", onto_check_info)
 
     def test_unknown_class(self) -> None:
         onto_check_info = ProjectOntosInformation(
@@ -66,7 +66,7 @@ class TestCheckClassType:
                 "knora-api": OntoInfo(classes=["knoraClassA"], properties=[]),
             },
         )
-        assert _check_if_one_class_type_exists("test:classC", onto_check_info) == "Invalid Class Type"
+        assert _check_one_class_type_exists("test:classC", onto_check_info) == "Invalid Class Type"
 
     def test_unknown_prefix(self) -> None:
         onto_check_info = ProjectOntosInformation(
@@ -76,7 +76,7 @@ class TestCheckClassType:
                 "knora-api": OntoInfo(classes=["knoraClassA"], properties=[]),
             },
         )
-        assert _check_if_one_class_type_exists("other:classC", onto_check_info) == "Unknown ontology prefix"
+        assert _check_one_class_type_exists("other:classC", onto_check_info) == "Unknown ontology prefix"
 
     def test_diagnose_all_classes_no_problems(self) -> None:
         onto_check_info = ProjectOntosInformation(
@@ -87,7 +87,7 @@ class TestCheckClassType:
             },
         )
         test_classes = {"knora-api:knoraClassA": ["idA"], ":classB": ["idB"]}
-        assert not _check_if_all_class_types_exist(test_classes, onto_check_info)
+        assert not _check_all_class_types_exist(test_classes, onto_check_info)
 
     def test_diagnose_all_classes_problems(self) -> None:
         onto_check_info = ProjectOntosInformation(
@@ -98,7 +98,7 @@ class TestCheckClassType:
             },
         )
         test_classes = {"knoraClassA": ["idA"], ":classD": ["idD"]}
-        assert _check_if_all_class_types_exist(test_classes, onto_check_info) == [
+        assert _check_all_class_types_exist(test_classes, onto_check_info) == [
             (":classD", ["idD"], "Invalid Class Type")
         ]
 
@@ -112,7 +112,7 @@ class TestCheckProperties:
                 "knora-api": OntoInfo(classes=[], properties=["knoraPropA"]),
             },
         )
-        assert not _check_if_one_property_exists("knoraPropA", onto_check_info)
+        assert not _check_one_property_exists("knoraPropA", onto_check_info)
 
     def test_knora_prefix(self) -> None:
         onto_check_info = ProjectOntosInformation(
@@ -122,7 +122,7 @@ class TestCheckProperties:
                 "knora-api": OntoInfo(classes=[], properties=["knoraPropA"]),
             },
         )
-        assert not _check_if_one_property_exists("knora-api:knoraPropA", onto_check_info)
+        assert not _check_one_property_exists("knora-api:knoraPropA", onto_check_info)
 
     def test_no_default_prefix(self) -> None:
         onto_check_info = ProjectOntosInformation(
@@ -132,7 +132,7 @@ class TestCheckProperties:
                 "knora-api": OntoInfo(classes=[], properties=["knoraPropA"]),
             },
         )
-        assert not _check_if_one_property_exists(":propA", onto_check_info)
+        assert not _check_one_property_exists(":propA", onto_check_info)
 
     def test_default_prefix(self) -> None:
         onto_check_info = ProjectOntosInformation(
@@ -142,7 +142,7 @@ class TestCheckProperties:
                 "knora-api": OntoInfo(classes=[], properties=["knoraPropA"]),
             },
         )
-        assert not _check_if_one_property_exists("test:propB", onto_check_info)
+        assert not _check_one_property_exists("test:propB", onto_check_info)
 
     def test_unknown_prefix(self) -> None:
         onto_check_info = ProjectOntosInformation(
@@ -152,7 +152,7 @@ class TestCheckProperties:
                 "knora-api": OntoInfo(classes=[], properties=["knoraPropA"]),
             },
         )
-        assert _check_if_one_property_exists("other:propB", onto_check_info) == "Unknown ontology prefix"
+        assert _check_one_property_exists("other:propB", onto_check_info) == "Unknown ontology prefix"
 
     def test_unknown_property(self) -> None:
         onto_check_info = ProjectOntosInformation(
@@ -162,7 +162,7 @@ class TestCheckProperties:
                 "knora-api": OntoInfo(classes=[], properties=["knoraPropA"]),
             },
         )
-        assert _check_if_one_property_exists("test:propC", onto_check_info) == "Invalid Property"
+        assert _check_one_property_exists("test:propC", onto_check_info) == "Invalid Property"
 
     def test_diagnose_all_properties_problems(self) -> None:
         onto_check_info = ProjectOntosInformation(
@@ -174,7 +174,7 @@ class TestCheckProperties:
         )
         test_properties = {"test:propB": ["idB"], "other:propB": ["idB"], "test:propD": ["idD"]}
         expected = [("other:propB", ["idB"], "Unknown ontology prefix"), ("test:propD", ["idD"], "Invalid Property")]
-        assert unordered(_check_if_all_properties_exist(test_properties, onto_check_info)) == expected
+        assert unordered(_check_all_properties_exist(test_properties, onto_check_info)) == expected
 
     def test_diagnose_all_properties_no_problems(self) -> None:
         onto_check_info = ProjectOntosInformation(
@@ -185,10 +185,10 @@ class TestCheckProperties:
             },
         )
         test_properties = {"test:propB": ["idB"], "knoraPropA": ["idA"]}
-        assert not unordered(_check_if_all_properties_exist(test_properties, onto_check_info))
+        assert not unordered(_check_all_properties_exist(test_properties, onto_check_info))
 
 
-def test_find_if_all_classes_and_properties_exist_in_onto() -> None:
+def test_find_all_classes_and_properties_exist_in_onto() -> None:
     onto_check_info = ProjectOntosInformation(
         default_ontology_prefix="test",
         onto_lookup={
@@ -198,10 +198,10 @@ def test_find_if_all_classes_and_properties_exist_in_onto() -> None:
     )
     classes = {"knoraClassA": ["idA"]}
     properties = {"knora-api:knoraPropA": ["idA"]}
-    _find_if_all_classes_and_properties_exist_in_onto(classes, properties, onto_check_info)
+    _find_all_classes_and_properties_exist_in_onto(classes, properties, onto_check_info)
 
 
-def test_find_if_all_classes_and_properties_exist_in_onto_problem() -> None:
+def test_find_all_classes_and_properties_exist_in_onto_problem() -> None:
     onto_check_info = ProjectOntosInformation(
         default_ontology_prefix="test",
         onto_lookup={
@@ -212,7 +212,7 @@ def test_find_if_all_classes_and_properties_exist_in_onto_problem() -> None:
     classes = {"knora": ["idA"]}
     properties = {"knora-api:knoraPropA": ["idA"]}
     with pytest.raises(UserError):
-        _find_if_all_classes_and_properties_exist_in_onto(classes, properties, onto_check_info)
+        _find_all_classes_and_properties_exist_in_onto(classes, properties, onto_check_info)
 
 
 def test_get_prefix_and_prop_cls_identifier() -> None:

--- a/test/unittests/commands/xmlupload/test_ontology_lookup_models.py
+++ b/test/unittests/commands/xmlupload/test_ontology_lookup_models.py
@@ -1,17 +1,17 @@
 from pytest_unordered import unordered
 
 from dsp_tools.commands.xmlupload.models.ontology_lookup_models import (
-    _get_all_classes_from_graph,
-    _get_all_properties_from_graph,
+    _get_all_classes_from_json,
+    _get_all_properties_from_json,
     _remove_prefixes,
     extract_classes_properties_from_onto,
 )
 
 
-class TestGetAllClassesFromGraph:
+class TestGetAllClassesFromJson:
     @staticmethod
     def test_single_class() -> None:
-        test_graph = [
+        test_json = [
             {
                 "knora-api:isResourceClass": True,
                 "rdfs:label": "Sequenz einer Audio-Ressource",
@@ -21,12 +21,12 @@ class TestGetAllClassesFromGraph:
                 "@id": "testonto:AudioSequence",
             },
         ]
-        res_cls = _get_all_classes_from_graph(test_graph)
+        res_cls = _get_all_classes_from_json(test_json)
         assert res_cls == ["testonto:AudioSequence"]
 
     @staticmethod
     def test_property() -> None:
-        test_graph = [
+        test_json = [
             {
                 "rdfs:label": "URI",
                 "rdfs:subPropertyOf": {},
@@ -39,12 +39,12 @@ class TestGetAllClassesFromGraph:
                 "@id": "testonto:hasUri",
             },
         ]
-        res_cls = _get_all_classes_from_graph(test_graph)
+        res_cls = _get_all_classes_from_json(test_json)
         assert not res_cls
 
     @staticmethod
-    def test_from_graph_resources_and_properties() -> None:
-        test_graph = [
+    def test_from_json_resources_and_properties() -> None:
+        test_json = [
             {
                 "knora-api:isResourceClass": True,
                 "rdfs:label": "Sequenz einer Audio-Ressource",
@@ -65,12 +65,12 @@ class TestGetAllClassesFromGraph:
                 "@id": "testonto:hasUri",
             },
         ]
-        res_cls = _get_all_classes_from_graph(test_graph)
+        res_cls = _get_all_classes_from_json(test_json)
         assert res_cls == ["testonto:AudioSequence"]
 
 
-def test_get_all_properties_from_graph_haslinkto() -> None:
-    test_graph = [
+def test_get_all_properties_from_json_haslinkto() -> None:
+    test_json = [
         {
             "rdfs:label": "hasResource",
             "rdfs:subPropertyOf": {},
@@ -94,12 +94,12 @@ def test_get_all_properties_from_graph_haslinkto() -> None:
             "@id": "testonto:hasResourceValue",
         },
     ]
-    res_prop = _get_all_properties_from_graph(test_graph)
+    res_prop = _get_all_properties_from_json(test_json)
     assert res_prop == ["testonto:hasResource", "testonto:hasResourceValue"]
 
 
-def test_get_all_properties_from_graph_resources_and_properties() -> None:
-    test_graph = [
+def test_get_all_properties_from_json_resources_and_properties() -> None:
+    test_json = [
         {
             "knora-api:isResourceClass": True,
             "rdfs:label": "Sequenz einer Audio-Ressource",
@@ -120,12 +120,12 @@ def test_get_all_properties_from_graph_resources_and_properties() -> None:
             "@id": "testonto:hasUri",
         },
     ]
-    res_prop = _get_all_properties_from_graph(test_graph)
+    res_prop = _get_all_properties_from_json(test_json)
     assert res_prop == ["testonto:hasUri"]
 
 
 def test_deserialize_ontology() -> None:
-    test_graph = [
+    test_json = [
         {
             "knora-api:isResourceClass": True,
             "rdfs:label": "Annotation",
@@ -148,7 +148,7 @@ def test_deserialize_ontology() -> None:
             "rdfs:comment": "Represents a direct connection between two resources",
         },
     ]
-    res_onto = extract_classes_properties_from_onto(test_graph)
+    res_onto = extract_classes_properties_from_onto(test_json)
     assert res_onto.classes == ["Annotation"]
     assert res_onto.properties == ["hasLinkTo"]
 


### PR DESCRIPTION
- Name changes as suggested by Balduin in https://github.com/dasch-swiss/dsp-tools/pull/810/files
- Chaning the `UserError` in the the `InputError` as is the convention now if an error follows the new protocol, which this does.