### PR TITLE
chore(xmlupload): improve parse xml function

### DIFF
--- a/src/dsp_tools/utils/xml_utils.py
+++ b/src/dsp_tools/utils/xml_utils.py
@@ -30,8 +30,6 @@ def parse_and_clean_xml_file(input_file: Union[str, Path, etree._ElementTree[Any
         InputError: if the input is not of either the expected types
     """
 
-    # remove comments and processing instructions (commented out properties break the XMLProperty constructor)
-
     if isinstance(input_file, (str, Path)):
         tree = _parse_xml_file(input_file)
     else:
@@ -43,11 +41,13 @@ def parse_and_clean_xml_file(input_file: Union[str, Path, etree._ElementTree[Any
     return tree.getroot()
 
 
-def parse_and_remove_comments_xml_file(
+def parse_and_remove_comments_from_xml_file(
     input_file: Union[str, Path, etree._ElementTree[Any]],
 ) -> etree._Element:
     """
-    Parse an XML file with DSP-conform data
+    Parse an XML file with DSP-conform data,
+    and remove the comments and processing instructions
+    (commented out properties break the XMLProperty constructor)
 
     Args:
         input_file: path to the XML file, or parsed ElementTree
@@ -58,8 +58,6 @@ def parse_and_remove_comments_xml_file(
     Raises:
         InputError: if the input is not of either the expected types
     """
-
-    # remove comments and processing instructions (commented out properties break the XMLProperty constructor)
 
     if isinstance(input_file, (str, Path)):
         tree = _parse_xml_file(input_file)

--- a/src/dsp_tools/utils/xml_utils.py
+++ b/src/dsp_tools/utils/xml_utils.py
@@ -6,6 +6,7 @@ from typing import Any, Union
 
 from lxml import etree
 
+from dsp_tools.models.exceptions import InputError
 from dsp_tools.utils.create_logger import get_logger
 
 logger = get_logger(__name__)
@@ -26,7 +27,7 @@ def parse_and_clean_xml_file(input_file: Union[str, Path, etree._ElementTree[Any
         the root element of the parsed XML file
 
     Raises:
-        UserError: if the input is not of either the expected types
+        InputError: if the input is not of either the expected types
     """
 
     # remove comments and processing instructions (commented out properties break the XMLProperty constructor)
@@ -34,9 +35,37 @@ def parse_and_clean_xml_file(input_file: Union[str, Path, etree._ElementTree[Any
     if isinstance(input_file, (str, Path)):
         tree = _parse_xml_file(input_file)
     else:
-        tree = remove_comments_from_element_tree(input_file)
+        tree = input_file
+    tree = remove_comments_from_element_tree(tree)
 
-    _remove_qnames_and_transform_special_tags(tree)
+    tree = _remove_qnames_and_transform_special_tags(tree)
+
+    return tree.getroot()
+
+
+def parse_and_remove_comments_xml_file(
+    input_file: Union[str, Path, etree._ElementTree[Any]],
+) -> etree._Element:
+    """
+    Parse an XML file with DSP-conform data
+
+    Args:
+        input_file: path to the XML file, or parsed ElementTree
+
+    Returns:
+        the root element of the parsed XML file
+
+    Raises:
+        InputError: if the input is not of either the expected types
+    """
+
+    # remove comments and processing instructions (commented out properties break the XMLProperty constructor)
+
+    if isinstance(input_file, (str, Path)):
+        tree = _parse_xml_file(input_file)
+    else:
+        tree = input_file
+    tree = remove_comments_from_element_tree(tree)
 
     return tree.getroot()
 
@@ -100,9 +129,16 @@ def _parse_xml_file(input_file: Union[str, Path]) -> etree._ElementTree[etree._E
 
     Returns:
         element tree
+
+    Raises:
+        InputError: if the file contains a syntax error
     """
     parser = etree.XMLParser(remove_comments=True, remove_pis=True)
-    return etree.parse(source=input_file, parser=parser)
+    try:
+        return etree.parse(source=input_file, parser=parser)
+    except etree.XMLSyntaxError as err:
+        logger.error(f"The XML file contains the following syntax error: {err.msg}", exc_info=True)
+        raise InputError(f"The XML file contains the following syntax error: {err.msg}") from None
 
 
 def remove_namespaces_from_xml(

--- a/src/dsp_tools/utils/xml_utils.py
+++ b/src/dsp_tools/utils/xml_utils.py
@@ -30,15 +30,8 @@ def parse_and_clean_xml_file(input_file: Union[str, Path, etree._ElementTree[Any
         InputError: if the input is not of either the expected types
     """
 
-    if isinstance(input_file, (str, Path)):
-        tree = _parse_xml_file(input_file)
-    else:
-        tree = input_file
-    tree = remove_comments_from_element_tree(tree)
-
-    tree = _remove_qnames_and_transform_special_tags(tree)
-
-    return tree.getroot()
+    tree = parse_and_remove_comments_from_xml_file(input_file)
+    return _remove_qnames_and_transform_special_tags(tree)
 
 
 def parse_and_remove_comments_from_xml_file(
@@ -69,8 +62,8 @@ def parse_and_remove_comments_from_xml_file(
 
 
 def _remove_qnames_and_transform_special_tags(
-    input_tree: etree._ElementTree[etree._Element],
-) -> etree._ElementTree[etree._Element]:
+    input_tree: etree._Element,
+) -> etree._Element:
     """
     This function removes the namespace URIs from the elements' names
     and transforms the special tags <annotation>, <region>, and <link>
@@ -84,7 +77,7 @@ def _remove_qnames_and_transform_special_tags(
         cleaned tree
     """
     for elem in input_tree.iter():
-        elem.tag = etree.QName(elem).localname  # remove namespace URI in the element's name
+        elem.tag = etree.QName(elem).localname
         if elem.tag == "annotation":
             elem.attrib["restype"] = "Annotation"
             elem.tag = "resource"

--- a/src/dsp_tools/utils/xml_validation.py
+++ b/src/dsp_tools/utils/xml_validation.py
@@ -10,7 +10,7 @@ from lxml import etree
 
 from dsp_tools.models.exceptions import InputError
 from dsp_tools.utils.create_logger import get_logger
-from dsp_tools.utils.xml_utils import remove_namespaces_from_xml
+from dsp_tools.utils.xml_utils import parse_and_remove_comments_xml_file, remove_namespaces_from_xml
 
 logger = get_logger(__name__)
 
@@ -64,14 +64,7 @@ def _parse_schema_and_data_files(
         encoding="utf-8"
     ) as schema_file:
         xmlschema = etree.XMLSchema(etree.parse(schema_file))
-    if isinstance(input_file, (str, Path)):
-        try:
-            data_xml = etree.parse(source=input_file)
-        except etree.XMLSyntaxError as err:
-            logger.error(f"The XML file contains the following syntax error: {err.msg}", exc_info=True)
-            raise InputError(f"The XML file contains the following syntax error: {err.msg}") from None
-    else:
-        data_xml = input_file
+    data_xml = parse_and_remove_comments_xml_file(input_file)
     return data_xml, xmlschema
 
 

--- a/src/dsp_tools/utils/xml_validation.py
+++ b/src/dsp_tools/utils/xml_validation.py
@@ -10,7 +10,7 @@ from lxml import etree
 
 from dsp_tools.models.exceptions import InputError
 from dsp_tools.utils.create_logger import get_logger
-from dsp_tools.utils.xml_utils import parse_and_remove_comments_xml_file, remove_namespaces_from_xml
+from dsp_tools.utils.xml_utils import parse_and_remove_comments_from_xml_file, remove_namespaces_from_xml
 
 logger = get_logger(__name__)
 
@@ -64,7 +64,7 @@ def _parse_schema_and_data_files(
         encoding="utf-8"
     ) as schema_file:
         xmlschema = etree.XMLSchema(etree.parse(schema_file))
-    data_xml = parse_and_remove_comments_xml_file(input_file)
+    data_xml = parse_and_remove_comments_from_xml_file(input_file)
     return data_xml, xmlschema
 
 


### PR DESCRIPTION
Currently for the validate xml, the comments were not removed. This caused problems when finding the `encodings` attributes. However, we need the namespaces for the first validation step. Therefore a function was created that only parses the file and removes the comments.