### PR TITLE
chore(ci): make logging file available after e2e test (DEV-3436)

### DIFF
--- a/.github/workflows/tests-on-push.yml
+++ b/.github/workflows/tests-on-push.yml
@@ -93,7 +93,7 @@ jobs:
         run: poetry run dsp-tools stop-stack
       - name: Prepare timestamp
         id: prepare-timestamp
-        run: echo "TIMESTAMP=$(echo ${{ github.event.head_commit.timestamp }} |  sed 's/[^0-9,a-z,A-Z]/\-/g'))"
+        run: echo "TIMESTAMP=$(echo ${{ github.event.head_commit.timestamp }} | sed 's/\+01:00//g' |  sed 's/[^0-9,a-z,A-Z]/\-/g')"
       - name: make logging file available
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/tests-on-push.yml
+++ b/.github/workflows/tests-on-push.yml
@@ -91,11 +91,14 @@ jobs:
         run: poetry exec e2e-tests
       - name: stop stack  # see if this command can run (it isn't tested anywhere else)
         run: poetry run dsp-tools stop-stack
+      - name: Prepare timestamp
+        id: prepare-timestamp
+        run: echo "TIMESTAMP=$(echo ${{ github.event.head_commit.timestamp }} |  sed 's/[^0-9,a-z,A-Z]/\-/g'))"
       - name: make logging file available
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: logging_${{ github.event.head_commit.timestamp }}.log
+          name: logging_${{ steps.prepare-timestamp.outputs.TIMESTAMP }}.log
           path: /home/runner/.dsp-tools/logging.log
           compression-level: 0
 

--- a/.github/workflows/tests-on-push.yml
+++ b/.github/workflows/tests-on-push.yml
@@ -91,6 +91,13 @@ jobs:
         run: poetry exec e2e-tests
       - name: stop stack  # see if this command can run (it isn't tested anywhere else)
         run: poetry run dsp-tools stop-stack
+      - name: make logging file available
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: logging_${{ github.event.head_commit.timestamp }}.log
+          path: /home/runner/.dsp-tools/logging.log
+          compression-level: 0
 
 
   distribution:

--- a/.github/workflows/tests-on-push.yml
+++ b/.github/workflows/tests-on-push.yml
@@ -91,17 +91,11 @@ jobs:
         run: poetry exec e2e-tests
       - name: stop stack  # see if this command can run (it isn't tested anywhere else)
         run: poetry run dsp-tools stop-stack
-      - name: Prepare timestamp
-        id: prepare-timestamp
-        run: |
-          TIMESTAMP=$(echo ${{ github.event.head_commit.timestamp }} | sed 's/\+01:00//g')
-          TIMESTAMP=$(echo $TIMESTAMP | sed 's/[^0-9,a-z,A-Z]/\-/g')
-          echo "TIMESTAMP=$TIMESTAMP" >> $GITHUB_OUTPUT
       - name: make logging file available
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: logging_${{ steps.prepare-timestamp.outputs.TIMESTAMP }}.log
+          name: logging.log
           path: /home/runner/.dsp-tools/logging.log
           compression-level: 0
 

--- a/.github/workflows/tests-on-push.yml
+++ b/.github/workflows/tests-on-push.yml
@@ -96,7 +96,7 @@ jobs:
         run: |
           TIMESTAMP=$(echo ${{ github.event.head_commit.timestamp }} | sed 's/\+01:00//g')
           TIMESTAMP=$(echo $TIMESTAMP | sed 's/[^0-9,a-z,A-Z]/\-/g')
-          echo "TIMESTAMP=$TIMESTAMP" >> $GITHUB_ENV
+          echo "TIMESTAMP=$TIMESTAMP" >> $GITHUB_OUTPUT
       - name: make logging file available
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/tests-on-push.yml
+++ b/.github/workflows/tests-on-push.yml
@@ -93,7 +93,10 @@ jobs:
         run: poetry run dsp-tools stop-stack
       - name: Prepare timestamp
         id: prepare-timestamp
-        run: echo "TIMESTAMP=$(echo ${{ github.event.head_commit.timestamp }} | sed 's/\+01:00//g' |  sed 's/[^0-9,a-z,A-Z]/\-/g')"
+        run: |
+          TIMESTAMP=$(echo ${{ github.event.head_commit.timestamp }} | sed 's/\+01:00//g'
+          TIMESTAMP=$(echo $TIMESTAMP | sed 's/[^0-9,a-z,A-Z]/\-/g')
+          echo "TIMESTAMP=$TIMESTAMP" >> $GITHUB_ENV
       - name: make logging file available
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/tests-on-push.yml
+++ b/.github/workflows/tests-on-push.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Prepare timestamp
         id: prepare-timestamp
         run: |
-          TIMESTAMP=$(echo ${{ github.event.head_commit.timestamp }} | sed 's/\+01:00//g'
+          TIMESTAMP=$(echo ${{ github.event.head_commit.timestamp }} | sed 's/\+01:00//g')
           TIMESTAMP=$(echo $TIMESTAMP | sed 's/[^0-9,a-z,A-Z]/\-/g')
           echo "TIMESTAMP=$TIMESTAMP" >> $GITHUB_ENV
       - name: make logging file available

--- a/src/dsp_tools/utils/logger_config.py
+++ b/src/dsp_tools/utils/logger_config.py
@@ -20,7 +20,7 @@ def logger_config() -> None:
     text_format = "<level>{time:YYYY-MM-DD HH:mm:ss.SSS} | {level: <8} | {message}</level>"
     rotation_size = "100 MB"
     retention_number = 30
-    timestamp_str = datetime.now().strftime("%Y%m%d-%H%M")
+    timestamp_str = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
 
     logger.add(
         sink=logger_savepath,

--- a/test/e2e/commands/test_create_get_xmlupload.py
+++ b/test/e2e/commands/test_create_get_xmlupload.py
@@ -67,7 +67,7 @@ class TestCreateGetXMLUpload(unittest.TestCase):
             server=self.server,
             user=self.user,
             password=self.password,
-            imgdir="path/to/nowhere",
+            imgdir=self.imgdir,
             sipi=self.sipi,
             config=UploadConfig(),
         )

--- a/test/e2e/commands/test_create_get_xmlupload.py
+++ b/test/e2e/commands/test_create_get_xmlupload.py
@@ -67,7 +67,7 @@ class TestCreateGetXMLUpload(unittest.TestCase):
             server=self.server,
             user=self.user,
             password=self.password,
-            imgdir=self.imgdir,
+            imgdir="path/to/nowhere",
             sipi=self.sipi,
             config=UploadConfig(),
         )

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -1,13 +1,7 @@
-import pytest
-
 from dsp_tools.utils.logger_config import logger_config
 
-# @pytest.fixture(scope="session", autouse=True)
-# def _initialize_logging() -> None:
-#     logger_config()
 
-
-def pytest_sessionstart(session: pytest.Session) -> None:  # noqa: ARG001 (unused function argument)
+def pytest_sessionstart() -> None:
     """
     Called after the Session object has been created
     and before performing collection and entering the run test loop.

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+
+from dsp_tools.utils.logger_config import logger_config
+
+# @pytest.fixture(scope="session", autouse=True)
+# def _initialize_logging() -> None:
+#     logger_config()
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:  # noqa: ARG001 (unused function argument)
+    """
+    Called after the Session object has been created
+    and before performing collection and entering the run test loop.
+    See https://docs.pytest.org/en/latest/reference/reference.html#pytest.hookspec.pytest_sessionstart.
+    """
+    logger_config()


### PR DESCRIPTION
<p><a href="https://linear.app/dasch/issue/DEV-3436/make-logging-available-after-ci-test-runs">DEV-3436 make logging available after CI test runs</a></p>