### PR TITLE
chore(mypy): disallow untyped defs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ pythonpath = [".", "src", "test"]
 ignore_missing_imports = true                                 # TODO: deactivate this
 show_column_numbers = true
 strict = true
+disallow_untyped_defs = true
 exclude = [
     "src/dsp_tools/models/datetimestamp.py",                  # TODO: activate this
     "src/dsp_tools/models/langstring.py",                     # TODO: activate this


### PR DESCRIPTION
By default the bodies of functions without annotations are not type checked. So, to be more strict with typing, it would be better to disallow functions that are not annotated, see https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-disallow-untyped-defs.