### PR TITLE
chore: set api log level in docker-compose.yml

### DIFF
--- a/src/dsp_tools/resources/start-stack/docker-compose.yml
+++ b/src/dsp_tools/resources/start-stack/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - KNORA_WEBAPI_ALLOW_RELOAD_OVER_HTTP=true
       - KNORA_WEBAPI_KNORA_API_EXTERNAL_HOST=0.0.0.0
       - KNORA_WEBAPI_KNORA_API_EXTERNAL_PORT=3333
+      - DSP_API_LOG_LEVEL=INFO
 
   sipi:
     # on the verge of every deployment (fortnightly), take the same tag as DSP-API


### PR DESCRIPTION
From this PR (https://github.com/dasch-swiss/dsp-api/pull/3165) on, DSP-API needs a new environment variable.