### PR TITLE
chore(ci): fix ruff format checking

### DIFF
--- a/.github/workflows/tests-on-push.yml
+++ b/.github/workflows/tests-on-push.yml
@@ -38,7 +38,7 @@ jobs:
         uses: ./.github/actions/setup
       - name: Linting with ruff
         run: poetry exec ruff-check-github
-      - name: Formatting with ruff
+      - name: Check formatting with ruff
         run: poetry exec ruff-format
       - name: Linting with mypy
         run: poetry exec mypy

--- a/.github/workflows/tests-on-push.yml
+++ b/.github/workflows/tests-on-push.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Linting with ruff
         run: poetry exec ruff-check-github
       - name: Check formatting with ruff
-        run: poetry exec ruff-format
+        run: poetry exec ruff-format-check
       - name: Linting with mypy
         run: poetry exec mypy
       - name: Linting with darglint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ ruff-check = "ruff check . --ignore=A002,D101,D102,PLR0913,PLR2004,PLW0603"
 ruff-check-github = """
     ruff check . --output-format=github --ignore=A002,D101,D102,PLR0913,PLR2004,PLW0603
 """
-ruff-format = "ruff format --check ."
+ruff-format-check = "ruff format --check ."
 mypy = "mypy ."
 unittests = "pytest test/unittests/"
 integration-tests = "pytest test/integration/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ ruff-check = "ruff check . --ignore=A002,D101,D102,PLR0913,PLR2004,PLW0603"
 ruff-check-github = """
     ruff check . --output-format=github --ignore=A002,D101,D102,PLR0913,PLR2004,PLW0603
 """
-ruff-format = "ruff format ."
+ruff-format = "ruff format --check ."
 mypy = "mypy ."
 unittests = "pytest test/unittests/"
 integration-tests = "pytest test/integration/"

--- a/src/dsp_tools/commands/excel2xml/excel2xml_cli.py
+++ b/src/dsp_tools/commands/excel2xml/excel2xml_cli.py
@@ -524,12 +524,10 @@ def excel2xml(
                 print(f"WARNING: {warning.message}")
 
     if success:
-        print(f"XML file successfully written to '{output_file!s}'")
+        print(f"XML file successfully written to '{output_file}'")
     else:
         red = "\033[31m"
         end = "\033[0m"
-        print(
-            f"{red}Some problems occurred. The XML file was written to '{output_file!s}', but it might be corrupt{end}"
-        )
+        print(f"{red}Some problems occurred. The XML file was written to '{output_file}', but it might be corrupt{end}")
 
     return success, catched_warnings


### PR DESCRIPTION
until now, the `ruff format .` in the CI checks didn't really check anything. Ruff must be called with the `--check` flag in order to exit with non-0 if a wrong formatting is found.