### PR TITLE
chore(start-stack): remove network from docker-compose.yml

### DIFF
--- a/src/dsp_tools/resources/start-stack/docker-compose.yml
+++ b/src/dsp_tools/resources/start-stack/docker-compose.yml
@@ -9,8 +9,6 @@ services:
       - db
     ports:
       - "3333:3333"
-    networks:
-      - knora-net
     environment:
       - TZ=Europe/Zurich
       - KNORA_AKKA_LOGLEVEL=DEBUG
@@ -39,8 +37,6 @@ services:
       - ./tmp:/tmp
       - .:/sipi/config
       - ./sipi/images:/sipi/images
-    networks:
-      - knora-net
     environment:
       - TZ=Europe/Zurich
       - SIPI_EXTERNAL_PROTOCOL=http
@@ -58,8 +54,6 @@ services:
     image: daschswiss/dsp-app:v11.9.1
     ports:
       - "4200:4200"
-    networks:
-      - knora-net
 
   db:
     # on the verge of every deployment (fortnightly), update the "image" value from the "db" value of
@@ -67,8 +61,6 @@ services:
     image: daschswiss/apache-jena-fuseki:5.0.0-2
     ports:
       - "3030:3030"
-    networks:
-      - knora-net
     environment:
       - TZ=Europe/Zurich
       - ADMIN_PASSWORD=test
@@ -83,8 +75,6 @@ services:
     volumes:
       - ./sipi/images:/opt/images
       - ./sipi/tmp-dsp-ingest:/opt/temp
-    networks:
-      - knora-net
     environment:
       - SERVICE_HOST=0.0.0.0
       - SERVICE_PORT=3340
@@ -95,7 +85,3 @@ services:
       - JWT_ISSUER=0.0.0.0:3333
       - JWT_SECRET=UP 4888, nice 4-8-4 steam engine
       - SIPI_USE_LOCAL_DEV=false
-
-networks:
-  knora-net:
-    name: knora-net


### PR DESCRIPTION
As per https://docs.docker.com/compose/networking/, `docker compose` sets up a default network, and each container joins that default network.