### PR TITLE
chore: Add db configuration to ingest container

### DIFF
--- a/src/dsp_tools/resources/start-stack/docker-compose.yml
+++ b/src/dsp_tools/resources/start-stack/docker-compose.yml
@@ -67,6 +67,7 @@ services:
     volumes:
       - ./sipi/images:/opt/images
       - ./sipi/tmp-dsp-ingest:/opt/temp
+      - ingest-db:/opt/db
     environment:
       - SERVICE_LOG_FORMAT=text
       - STORAGE_ASSET_DIR=/opt/images
@@ -75,3 +76,7 @@ services:
       - JWT_ISSUER=0.0.0.0:3333
       - JWT_SECRET=UP 4888, nice 4-8-4 steam engine
       - SIPI_USE_LOCAL_DEV=false
+      - DB_JDBC_URL=jdbc:sqlite:/opt/db/ingest.sqlite
+
+volumes:
+  ingest-db:


### PR DESCRIPTION
Use a docker volume to store the ingest sqlite file persistently.

From the upcoming dsp-ingest release on the service requires an sqlite file to start.
The location is configured with the jdbc location.
The service will create and maintain that file by itself.
In order to retain the database's state it is stored in a docker volume.

This is the same change in the dsp-api setup:
https://github.com/dasch-swiss/dsp-api/pull/3304/files