### PR TITLE
fix: Urlencode filenames when uploading files to ingesta (DEV-3865)

### DIFF
--- a/src/dsp_tools/commands/xmlupload/models/ingest.py
+++ b/src/dsp_tools/commands/xmlupload/models/ingest.py
@@ -1,9 +1,8 @@
+import urllib
 from dataclasses import dataclass
 from dataclasses import field
 from pathlib import Path
 from typing import Protocol
-from urllib.parse import quote_plus
-from urllib.parse import urljoin
 
 import requests
 from loguru import logger
@@ -94,8 +93,8 @@ class DspIngestClientLive(AssetClient):
         Returns:
             IngestResponse: The internal filename of the uploaded file.
         """
-        filename = quote_plus(filepath.name)
-        url = urljoin(self.dsp_ingest_url, f"/projects/{self.shortcode}/assets/ingest/{filename}")
+        filename = urllib.parse.quote(filepath.name)
+        url = f"{self.dsp_ingest_url}/projects/{self.shortcode}/assets/ingest/{filename}"
         err = f"Failed to ingest {filepath} to '{url}'."
         with open(filepath, "rb") as binary_io:
             try:

--- a/src/dsp_tools/commands/xmlupload/models/ingest.py
+++ b/src/dsp_tools/commands/xmlupload/models/ingest.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 from dataclasses import field
 from pathlib import Path
 from typing import Protocol
+from urllib.parse import quote_plus
+from urllib.parse import urljoin
 
 import requests
 from loguru import logger
@@ -92,7 +94,8 @@ class DspIngestClientLive(AssetClient):
         Returns:
             IngestResponse: The internal filename of the uploaded file.
         """
-        url = f"{self.dsp_ingest_url}/projects/{self.shortcode}/assets/ingest/{filepath.name}"
+        filename = quote_plus(filepath.name)
+        url = urljoin(self.dsp_ingest_url, f"/projects/{self.shortcode}/assets/ingest/{filename}")
         err = f"Failed to ingest {filepath} to '{url}'."
         with open(filepath, "rb") as binary_io:
             try:

--- a/test/unittests/commands/xmlupload/models/test_ingest.py
+++ b/test/unittests/commands/xmlupload/models/test_ingest.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from urllib.parse import quote_plus
 
 import pytest
 from requests_mock import Mocker
@@ -25,11 +26,12 @@ def ingest_client(dsp_ingest_url: str, shortcode: str) -> DspIngestClientLive:
 
 @pytest.fixture()
 def tmp_file(tmp_path: Path) -> Path:
-    return tmp_path / "filename.xml"
+    return tmp_path / "éèêëàâæçîïôœùûüÿ.xml"
 
 
 def _make_url(dsp_ingest_url: str, shortcode: str, file: Path) -> str:
-    return f"{dsp_ingest_url}/projects/{shortcode}/assets/ingest/{file.name}"
+    filename = quote_plus(file.name)
+    return f"{dsp_ingest_url}/projects/{shortcode}/assets/ingest/{filename}"
 
 
 def test_ingest_success(

--- a/test/unittests/commands/xmlupload/models/test_ingest.py
+++ b/test/unittests/commands/xmlupload/models/test_ingest.py
@@ -1,5 +1,5 @@
+import urllib
 from pathlib import Path
-from urllib.parse import quote_plus
 
 import pytest
 from requests_mock import Mocker
@@ -26,11 +26,11 @@ def ingest_client(dsp_ingest_url: str, shortcode: str) -> DspIngestClientLive:
 
 @pytest.fixture()
 def tmp_file(tmp_path: Path) -> Path:
-    return tmp_path / "éèêëàâæçîïôœùûüÿ.xml"
+    return tmp_path / "éèêëàâæç îïôœùûüÿ.xml"
 
 
 def _make_url(dsp_ingest_url: str, shortcode: str, file: Path) -> str:
-    filename = quote_plus(file.name)
+    filename = urllib.parse.quote(file.name)
     return f"{dsp_ingest_url}/projects/{shortcode}/assets/ingest/{filename}"
 
 


### PR DESCRIPTION
In order to support filename containing special characters the filename in the url for the request to the ingest service must be properly url encoded.