### PR TITLE
chore: don't ignore ARG001 in pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,6 @@ repos:
       - id: ruff
         args:
           - --ignore=A002  # builtin-argument-shadowing
-          - --ignore=ARG001  # unused function argument
           - --ignore=D101  # undocumented-public-class
           - --ignore=D102  # undocumented-public-method
           - --ignore=F841  # unused-variable


### PR DESCRIPTION
In principle, the linter ignore lists should be the same in all places. This means, if a rule is ignored in the GitHub CI, it should also be ignored in the pre-commit-hooks, and vice versa. 

A while ago, `ARG001` was added to the ignore list in the pre-commit-hooks, because during WIP, it's more convenient if this rule is not checked. That seems logical. 

However, there is a problem: 3 files in our codebase contain an inline-ignore (`# noqa: ARG001 (unused argument)`). Whenever one of these files is modified, the pre-commit-hooks fail, because they don't allow an inline-comment for an already ignored rule. When this error occurs, it is very difficult to understand what is going on.

It would be cleaner to have the same ignore lists in all places. During WIP, one can commit in the Terminal using `git commit -m "message" --no-verify`.