### PR TITLE
fix(validate-data): prevent SimpleText Class shape to be used at the wrong place (DEV-4224)

### DIFF
--- a/test/unittests/commands/validate_data/fixtures_onto.py
+++ b/test/unittests/commands/validate_data/fixtures_onto.py
@@ -71,6 +71,23 @@ def one_prop() -> Graph:
 
 
 @pytest.fixture
+def link_prop() -> Graph:
+    ttl = f"""{PREFIXES}
+    onto:testHasLinkTo a owl:ObjectProperty ;
+        rdfs:label "Test In-built hasLinkTo" ;
+        knora-api:isEditable true ;
+        knora-api:isLinkProperty true ;
+        knora-api:isResourceProperty true ;
+        knora-api:objectType knora-api:Resource ;
+        salsah-gui:guiElement salsah-gui:Searchbox ;
+        rdfs:subPropertyOf knora-api:hasLinkTo .
+    """
+    g = Graph()
+    g.parse(data=ttl, format="ttl")
+    return g
+
+
+@pytest.fixture
 def card_1() -> Graph:
     ttl = f"""{PREFIXES}
     onto:ClassMixedCard a owl:Class ;

--- a/test/unittests/commands/validate_data/test_sparql_value_shacl.py
+++ b/test/unittests/commands/validate_data/test_sparql_value_shacl.py
@@ -5,8 +5,9 @@ from rdflib import Graph
 from rdflib import Namespace
 
 from dsp_tools.commands.validate_data.sparql.value_shacl import _add_property_shapes_to_class_shapes
+from dsp_tools.commands.validate_data.sparql.value_shacl import _construct_link_value_shape
 from dsp_tools.commands.validate_data.sparql.value_shacl import _construct_one_property_type_shape_based_on_object_type
-from dsp_tools.commands.validate_data.sparql.value_shacl import _construct_one_property_type_shape_gui_element
+from dsp_tools.commands.validate_data.sparql.value_shacl import _construct_one_property_type_text_value
 
 ONTO = Namespace("http://0.0.0.0:3333/ontology/9999/onto/v2#")
 API_SHAPES = Namespace("http://api.knora.org/ontology/knora-api/shapes/v2#")
@@ -22,8 +23,16 @@ def test_construct_one_property_type_shape_based_on_object_type(one_res_one_prop
     assert next(res.objects(ONTO.testBoolean_PropShape, SH.node)) == API_SHAPES.BooleanValue_ClassShape
 
 
-def test_construct_one_property_type_shape_gui_element(one_richtext_prop: Graph) -> None:
-    res = _construct_one_property_type_shape_gui_element(
+def test_construct_link_value_shape(link_prop: Graph) -> None:
+    res = _construct_link_value_shape(link_prop)
+    assert len(res) == 3
+    assert next(res.objects(ONTO.testHasLinkTo_PropShape, SH.path)) == ONTO.testHasLinkTo
+    assert next(res.objects(ONTO.testHasLinkTo_PropShape, RDF.type)) == SH.PropertyShape
+    assert next(res.objects(ONTO.testHasLinkTo_PropShape, SH.node)) == API_SHAPES.LinkValue_ClassShape
+
+
+def test_construct_one_property_type_text_value(one_richtext_prop: Graph) -> None:
+    res = _construct_one_property_type_text_value(
         one_richtext_prop, "salsah-gui:Richtext", "api-shapes:FormattedTextValue_ClassShape"
     )
     assert len(res) == 3


### PR DESCRIPTION
```
<http://0.0.0.0:3333/ontology/9999/onto/v2#testDecimalSimpleText> a owl:ObjectProperty ;
    rdfs:label "Test Decimal" ;
    ns1:isEditable true ;
    ns1:isResourceProperty true ;
    ns1:objectType ns1:DecimalValue ;
    ns2:guiElement ns2:SimpleText ;
    rdfs:subPropertyOf ns1:hasValue .
```

The `SimpleText` gui element can be used with non `TextValue` value types.