### PR TITLE
fix(validate-data): revert to exclusion of properties through gui-order (DEV-4279)

### DIFF
--- a/src/dsp_tools/commands/validate_data/sparql/cardinality_shacl.py
+++ b/src/dsp_tools/commands/validate_data/sparql/cardinality_shacl.py
@@ -38,7 +38,6 @@ def _construct_resource_nodeshape(onto_graph: Graph) -> Graph:
         ?class a owl:Class ;
                knora-api:isResourceClass true ;
                knora-api:canBeInstantiated true .
-
     }
     """
     if results_graph := onto_graph.query(query_s).graph:
@@ -87,7 +86,6 @@ def _construct_1_cardinality(onto_graph: Graph) -> Graph:
           salsah-gui:guiOrder ?order ;
           owl:cardinality 1 .
       FILTER NOT EXISTS { ?propRestriction knora-api:isLinkValueProperty true }
-
     }
     """
     if results_graph := onto_graph.query(query_s).graph:
@@ -127,7 +125,6 @@ def _construct_0_1_cardinality(onto_graph: Graph) -> Graph:
           salsah-gui:guiOrder ?order ;
           owl:maxCardinality 1 .
       FILTER NOT EXISTS { ?propRestriction knora-api:isLinkValueProperty true }
-
     }
     """
     if results_graph := onto_graph.query(query_s).graph:
@@ -166,7 +163,6 @@ def _construct_1_n_cardinality(onto_graph: Graph) -> Graph:
           salsah-gui:guiOrder ?order ;
           owl:minCardinality 1 .
       FILTER NOT EXISTS { ?propRestriction knora-api:isLinkValueProperty true }
-
     }
     """
     if results_graph := onto_graph.query(query_s).graph:
@@ -202,7 +198,6 @@ def _construct_0_n_cardinality(onto_graph: Graph) -> Graph:
           salsah-gui:guiOrder ?order ;
           owl:minCardinality 0 .
       FILTER NOT EXISTS { ?propRestriction knora-api:isLinkValueProperty true }
-
     }
     """
     if results_graph := onto_graph.query(query_s).graph:

--- a/src/dsp_tools/commands/validate_data/sparql/cardinality_shacl.py
+++ b/src/dsp_tools/commands/validate_data/sparql/cardinality_shacl.py
@@ -28,13 +28,10 @@ def _construct_resource_nodeshape(onto_graph: Graph) -> Graph:
     PREFIX dash: <http://datashapes.org/dash#>
 
     CONSTRUCT {
-
         ?class a sh:NodeShape ;
                 sh:property api-shapes:rdfsLabel_Shape ;
                 dash:closedByTypes true .
-
     } WHERE {
-
         ?class a owl:Class ;
                knora-api:isResourceClass true ;
                knora-api:canBeInstantiated true .
@@ -65,7 +62,6 @@ def _construct_1_cardinality(onto_graph: Graph) -> Graph:
     PREFIX dash: <http://datashapes.org/dash#>
 
     CONSTRUCT {
-
       ?class sh:property [
           a sh:PropertyShape ;
           sh:path ?propRestriction ;
@@ -74,9 +70,7 @@ def _construct_1_cardinality(onto_graph: Graph) -> Graph:
           sh:severity sh:Violation ;
           sh:message "1" ;
       ] .
-
     } WHERE {
-
       ?class a owl:Class ;
           knora-api:isResourceClass true ;
           knora-api:canBeInstantiated true ;
@@ -104,7 +98,6 @@ def _construct_0_1_cardinality(onto_graph: Graph) -> Graph:
     PREFIX dash: <http://datashapes.org/dash#>
 
     CONSTRUCT {
-
       ?class sh:property [
           a sh:PropertyShape ;
           sh:path ?propRestriction ;
@@ -113,9 +106,7 @@ def _construct_0_1_cardinality(onto_graph: Graph) -> Graph:
           sh:severity sh:Violation ;
           sh:message "0-1" ;
       ] .
-
     } WHERE {
-
       ?class a owl:Class ;
           knora-api:isResourceClass true ;
           knora-api:canBeInstantiated true ;
@@ -143,7 +134,6 @@ def _construct_1_n_cardinality(onto_graph: Graph) -> Graph:
     PREFIX dash: <http://datashapes.org/dash#>
 
     CONSTRUCT {
-
       ?class sh:property [
           a sh:PropertyShape ;
           sh:path ?propRestriction ;
@@ -151,9 +141,7 @@ def _construct_1_n_cardinality(onto_graph: Graph) -> Graph:
           sh:severity sh:Violation ;
           sh:message "1-n" ;
       ] .
-
     } WHERE {
-
       ?class a owl:Class ;
           knora-api:isResourceClass true ;
           knora-api:canBeInstantiated true ;
@@ -181,14 +169,11 @@ def _construct_0_n_cardinality(onto_graph: Graph) -> Graph:
     PREFIX dash: <http://datashapes.org/dash#>
 
     CONSTRUCT {
-
       ?class sh:property [
           a sh:PropertyShape ;
           sh:path ?propRestriction ;
       ] .
-
     } WHERE {
-
       ?class a owl:Class ;
           knora-api:isResourceClass true ;
           knora-api:canBeInstantiated true ;

--- a/src/dsp_tools/commands/validate_data/sparql/cardinality_shacl.py
+++ b/src/dsp_tools/commands/validate_data/sparql/cardinality_shacl.py
@@ -38,7 +38,7 @@ def _construct_resource_nodeshape(onto_graph: Graph) -> Graph:
         ?class a owl:Class ;
                knora-api:isResourceClass true ;
                knora-api:canBeInstantiated true .
-               
+
     }
     """
     if results_graph := onto_graph.query(query_s).graph:
@@ -64,9 +64,9 @@ def _construct_1_cardinality(onto_graph: Graph) -> Graph:
     PREFIX api-shapes: <http://api.knora.org/ontology/knora-api/shapes/v2#>
     PREFIX knora-api:  <http://api.knora.org/ontology/knora-api/v2#>
     PREFIX dash: <http://datashapes.org/dash#>
-    
+
     CONSTRUCT {
-    
+
       ?class sh:property [
           a sh:PropertyShape ;
           sh:path ?propRestriction ;
@@ -75,20 +75,19 @@ def _construct_1_cardinality(onto_graph: Graph) -> Graph:
           sh:severity sh:Violation ;
           sh:message "1" ;
       ] .
-    
+
     } WHERE {
-    
+
       ?class a owl:Class ;
           knora-api:isResourceClass true ;
           knora-api:canBeInstantiated true ;
           rdfs:subClassOf ?restriction .
       ?restriction a owl:Restriction ;
           owl:onProperty ?propRestriction ;
+          salsah-gui:guiOrder ?order ;
           owl:cardinality 1 .
-    
-      ?propRestriction knora-api:isEditable true .
       FILTER NOT EXISTS { ?propRestriction knora-api:isLinkValueProperty true }
-    
+
     }
     """
     if results_graph := onto_graph.query(query_s).graph:
@@ -107,7 +106,7 @@ def _construct_0_1_cardinality(onto_graph: Graph) -> Graph:
     PREFIX dash: <http://datashapes.org/dash#>
 
     CONSTRUCT {
-    
+
       ?class sh:property [
           a sh:PropertyShape ;
           sh:path ?propRestriction ;
@@ -116,20 +115,19 @@ def _construct_0_1_cardinality(onto_graph: Graph) -> Graph:
           sh:severity sh:Violation ;
           sh:message "0-1" ;
       ] .
-    
+
     } WHERE {
-    
+
       ?class a owl:Class ;
           knora-api:isResourceClass true ;
           knora-api:canBeInstantiated true ;
           rdfs:subClassOf ?restriction .
       ?restriction a owl:Restriction ;
           owl:onProperty ?propRestriction ;
+          salsah-gui:guiOrder ?order ;
           owl:maxCardinality 1 .
-    
-      ?propRestriction knora-api:isEditable true .
       FILTER NOT EXISTS { ?propRestriction knora-api:isLinkValueProperty true }
-    
+
     }
     """
     if results_graph := onto_graph.query(query_s).graph:
@@ -148,7 +146,7 @@ def _construct_1_n_cardinality(onto_graph: Graph) -> Graph:
     PREFIX dash: <http://datashapes.org/dash#>
 
     CONSTRUCT {
-    
+
       ?class sh:property [
           a sh:PropertyShape ;
           sh:path ?propRestriction ;
@@ -156,20 +154,19 @@ def _construct_1_n_cardinality(onto_graph: Graph) -> Graph:
           sh:severity sh:Violation ;
           sh:message "1-n" ;
       ] .
-    
+
     } WHERE {
-    
+
       ?class a owl:Class ;
           knora-api:isResourceClass true ;
           knora-api:canBeInstantiated true ;
           rdfs:subClassOf ?restriction .
       ?restriction a owl:Restriction ;
           owl:onProperty ?propRestriction ;
+          salsah-gui:guiOrder ?order ;
           owl:minCardinality 1 .
-    
-      ?propRestriction knora-api:isEditable true .
       FILTER NOT EXISTS { ?propRestriction knora-api:isLinkValueProperty true }
-    
+
     }
     """
     if results_graph := onto_graph.query(query_s).graph:
@@ -188,25 +185,24 @@ def _construct_0_n_cardinality(onto_graph: Graph) -> Graph:
     PREFIX dash: <http://datashapes.org/dash#>
 
     CONSTRUCT {
-    
+
       ?class sh:property [
           a sh:PropertyShape ;
           sh:path ?propRestriction ;
       ] .
-    
+
     } WHERE {
-    
+
       ?class a owl:Class ;
           knora-api:isResourceClass true ;
           knora-api:canBeInstantiated true ;
           rdfs:subClassOf ?restriction .
       ?restriction a owl:Restriction ;
           owl:onProperty ?propRestriction ;
+          salsah-gui:guiOrder ?order ;
           owl:minCardinality 0 .
-    
-      ?propRestriction knora-api:isEditable true .
       FILTER NOT EXISTS { ?propRestriction knora-api:isLinkValueProperty true }
-    
+
     }
     """
     if results_graph := onto_graph.query(query_s).graph:

--- a/src/dsp_tools/commands/validate_data/sparql/value_shacl.py
+++ b/src/dsp_tools/commands/validate_data/sparql/value_shacl.py
@@ -38,10 +38,9 @@ def _add_property_shapes_to_class_shapes(onto: Graph) -> Graph:
           knora-api:isResourceClass true ;
           knora-api:canBeInstantiated true ;
           rdfs:subClassOf ?restriction .
-      ?restriction a owl:Restriction ;
-          owl:onProperty ?propRestriction .
-          
-      ?propRestriction knora-api:isEditable true .
+      ?restriction a owl:Restriction ;          
+          owl:onProperty ?propRestriction ;
+          salsah-gui:guiOrder ?order .
       FILTER NOT EXISTS { ?propRestriction knora-api:isLinkValueProperty true }
 
       BIND(IRI(CONCAT(str(?propRestriction), "_PropShape")) AS ?propShapesIRI)

--- a/test/integration/commands/validate_data/test_reformat_input.py
+++ b/test/integration/commands/validate_data/test_reformat_input.py
@@ -10,7 +10,7 @@ def test_to_data_rdf(data_xml: etree._Element) -> None:
     assert isinstance(res, ProjectDeserialised)
     assert res.info.shortcode == "9999"
     assert res.info.default_onto == "onto"
-    assert len(res.data.resources) == 15
+    assert len(res.data.resources) == 17
 
 
 if __name__ == "__main__":

--- a/test/integration/commands/validate_data/test_validate_data.py
+++ b/test/integration/commands/validate_data/test_validate_data.py
@@ -6,6 +6,7 @@ def test_to_data_rdf(data_xml: etree._Element) -> None:
     all_types = {x.attrib["restype"] for x in res_list}
     assert all_types == {
         "http://0.0.0.0:3333/ontology/9999/onto/v2#ClassWithEverything",
+        "http://0.0.0.0:3333/ontology/9999/onto/v2#TestStillImageRepresentation",
         "http://0.0.0.0:3333/ontology/9999/second-onto/v2#SecondOntoClass",
     }
     expected_names = {

--- a/testdata/validate-data/data/content_correct.xml
+++ b/testdata/validate-data/data/content_correct.xml
@@ -84,18 +84,6 @@
         </text-prop>
     </resource>
 
-    <resource label="Richtext" restype=":ClassWithEverything" id="id_richtext_with_formatting">
-        <text-prop name=":testRichtext">
-            <text encoding="xml">This is <em>italicized and <strong>bold</strong></em> text!</text>
-        </text-prop>
-    </resource>
-
-    <resource label="Richtext" restype=":ClassWithEverything" id="id_richtext_with_salsah_links">
-        <text-prop name=":testRichtext">
-            <text encoding="xml"><a class="salsah-link" href="IRI:id_simpletext:IRI">Text of Link</a></text>
-        </text-prop>
-    </resource>
-
     <resource label="Simpletext" restype=":ClassWithEverything" id="id_simpletext">
         <text-prop name=":testTextarea">
             <text encoding="utf8">Text line 1

--- a/testdata/validate-data/data/content_correct.xml
+++ b/testdata/validate-data/data/content_correct.xml
@@ -84,6 +84,18 @@
         </text-prop>
     </resource>
 
+    <resource label="Richtext" restype=":ClassWithEverything" id="id_richtext_with_formatting">
+        <text-prop name=":testRichtext">
+            <text encoding="xml">This is <em>italicized and <strong>bold</strong></em> text!</text>
+        </text-prop>
+    </resource>
+
+    <resource label="Richtext" restype=":ClassWithEverything" id="id_richtext_with_salsah_links">
+        <text-prop name=":testRichtext">
+            <text encoding="xml"><a class="salsah-link" href="IRI:id_simpletext:IRI">Text of Link</a></text>
+        </text-prop>
+    </resource>
+
     <resource label="Simpletext" restype=":ClassWithEverything" id="id_simpletext">
         <text-prop name=":testTextarea">
             <text encoding="utf8">Text line 1

--- a/testdata/validate-data/data/minimal_correct.xml
+++ b/testdata/validate-data/data/minimal_correct.xml
@@ -6,78 +6,82 @@
        shortcode="9999"
        default-ontology="onto">
 
-    <resource label="Empty" restype=":ClassWithEverything" id="id_0"/>
+    <resource label="Empty" restype=":ClassWithEverything" id="id_empty"/>
 
-    <resource label="Bool" restype=":ClassWithEverything" id="id_1">
+    <resource label="Bool" restype=":ClassWithEverything" id="id_bool">
         <boolean-prop name=":testBoolean">
             <boolean>true</boolean>
         </boolean-prop>
     </resource>
 
-    <resource label="Color" restype=":ClassWithEverything" id="id_2">
+    <resource label="Color" restype=":ClassWithEverything" id="id_color">
         <color-prop name=":testColor">
             <color>#00ff00</color>
         </color-prop>
     </resource>
 
-    <resource label="Date" restype=":ClassWithEverything" id="id_3">
+    <resource label="Date" restype=":ClassWithEverything" id="id_date">
         <date-prop name=":testSubDate1">
             <date>JULIAN:BCE:0700:BCE:0600</date>
         </date-prop>
     </resource>
 
-    <resource label="Decimal" restype=":ClassWithEverything" id="id_4">
+    <resource label="Decimal" restype=":ClassWithEverything" id="id_decimal">
         <decimal-prop name=":testDecimalSimpleText">
             <decimal>2.71</decimal>
         </decimal-prop>
     </resource>
 
-    <resource label="Geoname" restype=":ClassWithEverything" id="id_5">
+    <resource label="Geoname" restype=":ClassWithEverything" id="id_geoname">
         <geoname-prop name=":testGeoname">
             <geoname>1111111</geoname>
         </geoname-prop>
     </resource>
 
-    <resource label="Integer" restype=":ClassWithEverything" id="id_6">
+    <resource label="Integer" restype=":ClassWithEverything" id="id_integer">
         <integer-prop name=":testIntegerSimpleText">
             <integer>1</integer>
         </integer-prop>
     </resource>
 
-    <resource label="List" restype=":ClassWithEverything" id="id_7">
+    <resource label="List" restype=":ClassWithEverything" id="id_list">
         <list-prop list="onlyList" name=":testListProp">
             <list>n1</list>
         </list-prop>
     </resource>
 
-    <resource label="Link Prop" restype=":ClassWithEverything" id="id_8">
+    <resource label="Link Prop" restype=":ClassWithEverything" id="id_link">
         <resptr-prop name=":testHasLinkTo">
             <resptr>id_1</resptr>
         </resptr-prop>
     </resource>
 
-    <resource label="Richtext" restype=":ClassWithEverything" id="id_9">
+    <resource label="Richtext" restype=":ClassWithEverything" id="id_richtext">
         <text-prop name=":testRichtext">
             <text encoding="xml">Text</text>
         </text-prop>
     </resource>
 
-    <resource label="Simpletext" restype=":ClassWithEverything" id="id_10">
+    <resource label="Simpletext" restype=":ClassWithEverything" id="id_simpletext">
         <text-prop name=":testTextarea">
             <text encoding="utf8">Text</text>
         </text-prop>
     </resource>
 
-    <resource label="Time" restype=":ClassWithEverything" id="id_11">
+    <resource label="Time" restype=":ClassWithEverything" id="id_time">
         <time-prop name=":testTimeValue">
             <time>2019-10-23T13:45:12.01-14:00</time>
         </time-prop>
     </resource>
 
-    <resource label="Uri" restype=":ClassWithEverything" id="id_12">
+    <resource label="Uri" restype=":ClassWithEverything" id="id_uri">
         <uri-prop name=":testUriValue">
             <uri>https://dasch.swiss</uri>
         </uri-prop>
+    </resource>
+
+    <resource label="Image" restype=":TestStillImageRepresentation" id="id_image">
+        <bitstream>this/is/filepath/img.jpg</bitstream>
     </resource>
 
     <resource label="Class of second ontology" restype="second-onto:SecondOntoClass" id="second_onto_class">

--- a/testdata/validate-data/data/minimal_correct.xml
+++ b/testdata/validate-data/data/minimal_correct.xml
@@ -50,9 +50,10 @@
         </list-prop>
     </resource>
 
+    <resource label="Target of Link Prop" restype=":ClassWithEverything" id="id_link_target"/>
     <resource label="Link Prop" restype=":ClassWithEverything" id="id_link">
         <resptr-prop name=":testHasLinkTo">
-            <resptr>id_1</resptr>
+            <resptr>id_link_target</resptr>
         </resptr-prop>
     </resource>
 

--- a/testdata/validate-data/data/minimal_correct.xml
+++ b/testdata/validate-data/data/minimal_correct.xml
@@ -104,13 +104,13 @@
         <geometry-prop name="hasGeometry">
             <geometry permissions="prop-default">
                 {
-                "status": "active",
-                "type": "polygon",
-                "lineWidth": 5,
-                "points": [{"x": 0.4, "y": 0.6},
-                {"x": 0.5, "y": 0.9},
-                {"x": 0.8, "y": 0.9},
-                {"x": 0.7, "y": 0.6}]
+                    "status": "active",
+                    "type": "polygon",
+                    "lineWidth": 5,
+                    "points": [{"x": 0.4, "y": 0.6},
+                    {"x": 0.5, "y": 0.9},
+                    {"x": 0.8, "y": 0.9},
+                    {"x": 0.7, "y": 0.6}]
                 }
             </geometry>
         </geometry-prop>


### PR DESCRIPTION
Excluding properties through the gui-order is not a good idea because it is optional.

Better is through the triple: `?propRestriction knora-api:isEditable true .`

However, file values are editable too but are not yet implemented. Until file values are implemented it is easiest exclude properties through the gui-order.