### PR TITLE
fix(start-stack): allow erasing project on localhost (DEV-4422)

### DIFF
--- a/src/dsp_tools/resources/start-stack/docker-compose.yml
+++ b/src/dsp_tools/resources/start-stack/docker-compose.yml
@@ -45,6 +45,8 @@ services:
     # on the verge of every deployment (fortnightly), update the "image" value from the "app" value of
     # https://github.com/dasch-swiss/ops-deploy/blob/main/versions/RELEASE.json
     image: daschswiss/dsp-app:v11.22.1
+    volumes:
+      - ./dsp-app-config.json:/public/config/config.prod.json
     ports:
       - "4200:4200"
 

--- a/src/dsp_tools/resources/start-stack/dsp-app-config.json
+++ b/src/dsp_tools/resources/start-stack/dsp-app-config.json
@@ -1,0 +1,26 @@
+{
+    "dspRelease": "localhost",
+    "apiProtocol": "http",
+    "apiHost": "0.0.0.0",
+    "apiPort": 3333,
+    "apiPath": "",
+    "iiifProtocol": "http",
+    "iiifHost": "0.0.0.0",
+    "iiifPort": 1024,
+    "iiifPath": "",
+    "ingestUrl": "http://0.0.0.0:3340",
+    "geonameToken": "knora",
+    "jsonWebToken": "",
+    "logErrors": false,
+    "iriBase": "http://rdfh.ch",
+    "instrumentation": {
+      "environment": "production",
+      "rollbar": {
+        "enabled": false,
+        "accessToken": ""
+      }
+    },
+    "featureFlags": {
+      "allowEraseProjects": true
+    }
+  }


### PR DESCRIPTION
In the docker container of DSP-APP on a server, there are several config files, which are copied from the [DSP-APP repo](https://github.com/dasch-swiss/dsp-das/blob/eca422202fd5653569b6cff2abdf6a327aa2b49f/apps/dsp-app/src/config/): 

- `/public/config/config.test-server.json`
- `/public/config/config.prod.json`
- etc.

On our servers, the deployment scripts of ops-deploy copy [this file](https://github.com/dasch-swiss/ops-deploy/blob/main/roles/dsp-deploy/templates/app/conf/config-v11.json.j2) to `/home/knora/DSP/admin/conf/config.json`. This file contains an entry featureFlags.allowEraseProjects. The `/home/knora/DSP/docker-compose.yml` maps this file to `/public/config/config.prod.json` inside the DSP-APP container.

The confusing part is that inside the DSP-APP container, several config files exist, but only the `config.prod.json` is respected, even on servers other than prod. Also confusing: This file contains values that are wrong and don't have an effect, e.g. `"dspRelease": "2023.05.02"`. This is because they copy this file from the [DSP-APP repo](https://github.com/dasch-swiss/dsp-das/blob/eca422202fd5653569b6cff2abdf6a327aa2b49f/apps/dsp-app/src/config/), where it is not maintained any more.

This means that in DSP-TOOLS, we also need this config file. Unfortunately, all key-value pairs must be present, even if they don't make sense.

I just copied [this file](https://github.com/dasch-swiss/dsp-das/blob/eca422202fd5653569b6cff2abdf6a327aa2b49f/apps/dsp-app/src/config/config.prod.json), and slightly adapted it.