### PR TITLE
docs(xmllib): clarify that find_date_in_string() finds only 1 date

### DIFF
--- a/src/dsp_tools/xmllib/helpers.py
+++ b/src/dsp_tools/xmllib/helpers.py
@@ -308,9 +308,10 @@ def escape_reserved_xml_characters(text: str) -> str:
 def find_date_in_string(string: str) -> str | None:
     """
     Checks if a string contains a date value (single date, or date range),
-    and returns the first found date as DSP-formatted string,
-    [see XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/file-formats/xml-data-file/#date)
+    and returns the first found date as DSP-formatted string.
+    Once a date/date range has been found, subsequent dates/date ranges are ignored.
     Returns None if no date was found.
+    [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/file-formats/xml-data-file/#date).
 
     Notes:
         - All dates are interpreted in the Christian era and the Gregorian calendar.
@@ -359,6 +360,11 @@ def find_date_in_string(string: str) -> str | None:
         ```python
         result = xmllib.find_date_in_string("not a valid date")
         # result == None
+        ```
+
+        ```python
+        result = xmllib.find_date_in_string("first date: 2024. Second is ignored: 2025.")
+        # result == "GREGORIAN:CE:2024:CE:2024"
         ```
     """
 

--- a/test/unittests/xmllib/test_helpers.py
+++ b/test/unittests/xmllib/test_helpers.py
@@ -87,6 +87,11 @@ def test_create_standoff_link_to_uri_text_empty() -> None:
 
 
 class TestFindDate:
+    def test_find_date_in_string_ignore_subsequent(self) -> None:
+        assert find_date_in_string("x 1492-10-12, 2025-01-01x") == "GREGORIAN:CE:1492-10-12:CE:1492-10-12"
+        assert find_date_in_string("first date: 2024. Second is ignored: 2025.") == "GREGORIAN:CE:2024:CE:2024"
+       
+
     def test_find_date_in_string_iso(self) -> None:
         """template: 2021-01-01"""
         assert find_date_in_string("x 1492-10-12, x") == "GREGORIAN:CE:1492-10-12:CE:1492-10-12"

--- a/test/unittests/xmllib/test_helpers.py
+++ b/test/unittests/xmllib/test_helpers.py
@@ -90,7 +90,6 @@ class TestFindDate:
     def test_find_date_in_string_ignore_subsequent(self) -> None:
         assert find_date_in_string("x 1492-10-12, 2025-01-01x") == "GREGORIAN:CE:1492-10-12:CE:1492-10-12"
         assert find_date_in_string("first date: 2024. Second is ignored: 2025.") == "GREGORIAN:CE:2024:CE:2024"
-       
 
     def test_find_date_in_string_iso(self) -> None:
         """template: 2021-01-01"""


### PR DESCRIPTION
@Notheturtle @Nora-Olivia-Ammann While working with `find_date_in_string()`, I thought that the documentation could be clarified. Do you think that's helpful, or rather an unnecessary bloating of the docs?