### PR TITLE
chore: run `uv sync` before `just lint`, to prevent parallelism issues

### DIFF
--- a/justfile
+++ b/justfile
@@ -11,9 +11,15 @@ format:
     yamlfmt .
 
 
+# Rebuild the virtual environment (must be run before `just lint`, otherwise several tools will try to do it in parallel)
+[no-exit-message]
+uv-sync:
+    uv sync
+
+
 # Run all linters in parallel (see https://just.systems/man/en/running-tasks-in-parallel.html)
 [no-exit-message]
-lint: 
+lint: uv-sync
     #!/usr/bin/env -S parallel --shebang --ungroup --jobs {{ num_cpus() }}
     just ruff-check
     just ruff-format-check


### PR DESCRIPTION
Several tools that are called in `just lint` try to update the virtual environment. Because of the parallelization, this can result in conflicts.

Solution: call `uv sync` before `just lint`