### PR TITLE
refactor: add option to exclude request response text in logging

### DIFF
--- a/src/dsp_tools/commands/validate_data/api_clients.py
+++ b/src/dsp_tools/commands/validate_data/api_clients.py
@@ -30,7 +30,7 @@ class OntologyClient:
         timeout = 60
         log_request(RequestParameters("GET", url, timeout=timeout, headers=headers))
         response = requests.get(url=url, headers=headers, timeout=timeout)
-        log_response(response)
+        log_response(response, include_response_content=False)
         if not response.ok:
             raise InternalError(f"Failed Request: {response.status_code} {response.text}")
         return response.text
@@ -65,7 +65,7 @@ class OntologyClient:
         timeout = 10
         log_request(RequestParameters("GET", url, timeout=timeout, headers=headers))
         response = requests.get(url=url, headers=headers, timeout=timeout)
-        log_response(response)
+        log_response(response, include_response_content=False)
         if not response.ok:
             raise InternalError(f"Failed Request: {response.status_code} {response.text}")
         return response.text

--- a/src/dsp_tools/utils/request_utils.py
+++ b/src/dsp_tools/utils/request_utils.py
@@ -111,16 +111,17 @@ def log_request(params: RequestParameters, extra_headers: dict[str, Any] | None 
     logger.debug(f"REQUEST: {json.dumps(dumpobj, cls=SetEncoder)}")
 
 
-def log_response(response: Response) -> None:
+def log_response(response: Response, include_response_content: bool = True) -> None:
     """Log the response of a request."""
     dumpobj: dict[str, Any] = {
         "status_code": response.status_code,
         "headers": sanitize_headers(dict(response.headers)) if response.headers else "",
     }
-    try:
-        dumpobj["content"] = response.json()
-    except JSONDecodeError:
-        dumpobj["content"] = response.text
+    if include_response_content:
+        try:
+            dumpobj["content"] = response.json()
+        except JSONDecodeError:
+            dumpobj["content"] = response.text
     logger.debug(f"RESPONSE: {json.dumps(dumpobj)}")
 
 

--- a/src/dsp_tools/utils/request_utils.py
+++ b/src/dsp_tools/utils/request_utils.py
@@ -122,6 +122,8 @@ def log_response(response: Response, include_response_content: bool = True) -> N
             dumpobj["content"] = response.json()
         except JSONDecodeError:
             dumpobj["content"] = response.text
+    else:
+        dumpobj["content"] = "too big to be logged"
     logger.debug(f"RESPONSE: {json.dumps(dumpobj)}")
 
 


### PR DESCRIPTION
Logging the content of very large responses, for example when knora-api is requested, unnecessary blows up logging files.