### PR TITLE
chore: optimise `just clean`

### DIFF
--- a/justfile
+++ b/justfile
@@ -115,11 +115,12 @@ legacy-e2e-tests *FLAGS:
 # Remove artifact files
 [no-exit-message]
 clean:
-    -find . -name "*.pyc" -exec rm -rf {} \;
-    -find . -name __pycache__ -exec rm -rf {} \;
-    -find . -name .ruff_cache -exec rm -rf {} \;
-    -find . -name .pytest_cache -exec rm -rf {} \;
-    -find . -name .mypy_cache -exec rm -rf {} \;
+    -find . -name "*.pyc" -exec rm -rf {} +
+    -find . -name __pycache__ -exec rm -rf {} +
+    -find . -name .ruff_cache -exec rm -rf {} +
+    -find . -name .pytest_cache -exec rm -rf {} +
+    -find . -name .mypy_cache -exec rm -rf {} +
+    uv run dmypy restart
     -rm -rf ./*id2iri_mapping*.json
     -rm -rf ./*id2iri_[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]*.json
     -rm -f ./warnings.log


### PR DESCRIPTION
## Problem

`find ... -exec rm -rf {} \;` executes `rm -rf` once per match. This is not only inefficient, it can also lead to errors like this: `find: ./test/integration/utils/xml_parsing/__pycache__: No such file or directory`. 

This error occurs because the `find` command is trying to act on a directory that no longer exists. This typically happens when `rm -rf` deletes the directory before `find` completes its traversal.

## Solution

Use `find ... -exec rm -rf {} +` instead.

## Additionally: restart dmypy daemon

This is not directly related to the above problem, but it came to my mind that it would be good to restart the daemon when we execute `just clean`.