### PR TITLE
Switch command parts in start-stack to match documentation

### DIFF
--- a/src/dsp_tools/commands/start_stack.py
+++ b/src/dsp_tools/commands/start_stack.py
@@ -142,10 +142,10 @@ class StackHandler:
         Raises:
             UserError: if the database cannot be started
         """
-        cmd = "docker compose up db -d".split()
+        cmd = "docker compose up -d db".split()
         completed_process = subprocess.run(cmd, cwd=self.__docker_path_of_user, check=False)
         if not completed_process or completed_process.returncode != 0:
-            msg = "Cannot start the API: Error while executing 'docker compose up db -d'"
+            msg = "Cannot start the API: Error while executing 'docker compose up -d db'"
             logger.error(f"{msg}. completed_process = '{vars(completed_process)}'")
             raise UserError(msg)
 


### PR DESCRIPTION
This change adapts the use of docker compose up to the format
`docker compose up [OPTIONS] [SERVICE...]`
as described in the documentation at https://docs.docker.com/reference/cli/docker/compose/up/

While docker can deal with both syntaxes, Podman as drop-in replacement relies on the format described above.

Tested on Ubuntu 24.04.1 with package `podman-docker` by adapting the code inside the python environment.

Expected behaviour:
- No change with docker
- Podman will recognise `-d`