### PR TITLE
chore: PR checks should be triggered on PRs from forks

### DIFF
--- a/.github/workflows/test-latest-be.yml
+++ b/.github/workflows/test-latest-be.yml
@@ -5,9 +5,7 @@ name: integrate with latest BE
 on:
   schedule:
     - cron: "0 0 * * *"  # daily at midnight
-  push:
-    branches-ignore:
-      - refs/heads/main
+  pull_request:
 
 env:
   DSP_TOOLS_TESTING: true

--- a/.github/workflows/tests-on-push.yml
+++ b/.github/workflows/tests-on-push.yml
@@ -4,9 +4,7 @@ name: Tests on Push
 
 
 on:
-  push:
-    branches-ignore:
-      - refs/heads/main
+  pull_request:
 
 env:
   DSP_TOOLS_TESTING: true


### PR DESCRIPTION
Currently, a PR opened from a fork cannot be merged, because the mandatory checks aren't triggered (see https://github.com/dasch-swiss/dsp-tools/pull/1606). This is probably due to the wrong triggering conditions. 

`on: pull_request` makes sure that the tests are triggered if a PR is opened, synchronized, or reopened (see https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request)