### PR TITLE
edit

### DIFF
--- a/test/e2e/commands/conftest.py
+++ b/test/e2e/commands/conftest.py
@@ -1,10 +1,8 @@
 from collections.abc import Iterator
-from pathlib import Path
 
 import pytest
 
 from dsp_tools.cli.args import ServerCredentials
-from dsp_tools.commands.project.create.project_create_all import create_project
 from test.e2e.setup_testcontainers.ports import ExternalContainerPorts
 from test.e2e.setup_testcontainers.setup import get_containers
 
@@ -23,8 +21,3 @@ def creds(container_ports: ExternalContainerPorts) -> ServerCredentials:
         f"http://0.0.0.0:{container_ports.api}",
         f"http://0.0.0.0:{container_ports.ingest}",
     )
-
-
-@pytest.fixture(scope="module")
-def create_generic_project(creds: ServerCredentials) -> None:
-    assert create_project(Path("testdata/validate-data/generic/project.json"), creds)

--- a/test/e2e/commands/xmlupload/conftest.py
+++ b/test/e2e/commands/xmlupload/conftest.py
@@ -7,6 +7,7 @@ import pytest
 import requests
 
 from dsp_tools.cli.args import ServerCredentials
+from dsp_tools.commands.project.create.project_create_all import create_project
 from dsp_tools.commands.xmlupload.xmlupload import xmlupload
 
 # ruff: noqa: ARG001 Unused function argument
@@ -17,7 +18,7 @@ SECOND_ONTO_9999 = "second-onto"
 
 
 @pytest.fixture(scope="module")
-def project_iri_9999(create_generic_project, creds: ServerCredentials) -> str:
+def project_iri_9999(create_generic_project_9999, creds: ServerCredentials) -> str:
     get_project_route = f"{creds.server}/admin/projects/shortcode/{PROJECT_SHORTCODE_9999}"
     project_iri: str = requests.get(get_project_route, timeout=3).json()["project"]["id"]
     return project_iri
@@ -39,7 +40,12 @@ def second_onto_iri_9999(creds) -> str:
 
 
 @pytest.fixture(scope="module")
-def _xmlupload_minimal_correct_9999(create_generic_project, creds) -> None:
+def create_generic_project_9999(creds: ServerCredentials) -> None:
+    assert create_project(Path("testdata/validate-data/generic/project.json"), creds)
+
+
+@pytest.fixture(scope="module")
+def _xmlupload_minimal_correct_9999(create_generic_project_9999, creds) -> None:
     """
     If there is more than 1 module, pytest-xdist might execute this fixture for multiple modules at the same time.
     This can lead to the situation that multiple workers start the xmlupload of the same data at the same time.
@@ -55,7 +61,7 @@ def _xmlupload_minimal_correct_9999(create_generic_project, creds) -> None:
 
 
 @pytest.fixture(scope="module")
-def _xmlupload_text_parsing_9999(create_generic_project: None, creds: ServerCredentials) -> None:
+def _xmlupload_text_parsing_9999(create_generic_project_9999: None, creds: ServerCredentials) -> None:
     """
     If there is more than 1 module, pytest-xdist might execute this fixture for multiple modules at the same time.
     This can lead to the situation that multiple workers start the xmlupload of the same data at the same time.
@@ -71,7 +77,7 @@ def _xmlupload_text_parsing_9999(create_generic_project: None, creds: ServerCred
 
 
 @pytest.fixture(scope="module")
-def auth_header(create_generic_project, creds) -> dict[str, str]:
+def auth_header(create_generic_project_9999, creds) -> dict[str, str]:
     payload = {"email": creds.user, "password": creds.password}
     token: str = requests.post(f"{creds.server}/v2/authentication", json=payload, timeout=3).json()["token"]
     return {"Authorization": f"Bearer {token}"}


### PR DESCRIPTION
The fixture `create_generic_project` doesn't belong into `test/e2e/commands/conftest.py`, because it creates a JSON which is specific for validate-data (project 9999). It is a dublette of a fixture with the same name in `test/e2e/commands/validate_data/conftest.py`. 

But since it is also used in `test/e2e/commands/xmlupload/`, it makes more sense to have it there under the name `create_generic_project_9999`, to distinguish it from the "real" e2e testproject 4125 which is used inside that folder.