### PR TITLE
fix: remove support for python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Operating System :: OS Independent",
 ]
-requires-python = ">=3.12"
+requires-python = ">=3.12, <3.14"
 dependencies = [
     "argparse",
     "dotenv",


### PR DESCRIPTION
Adjust the Python version requirement to support versions between 3.12 and 3.14.