### PR TITLE
refactor: replace UnknownDOAPException control flow with DOAPResult type

### DIFF
--- a/src/dsp_tools/commands/get/exceptions.py
+++ b/src/dsp_tools/commands/get/exceptions.py
@@ -1,5 +1,0 @@
-from dsp_tools.error.exceptions import InternalError
-
-
-class UnknownDOAPException(InternalError):
-    """Class for errors that are raised if a DOAP cannot be parsed"""

--- a/src/dsp_tools/commands/get/get_permissions.py
+++ b/src/dsp_tools/commands/get/get_permissions.py
@@ -2,12 +2,13 @@ from typing import Any
 from typing import Literal
 
 import regex
+from loguru import logger
 
 from dsp_tools.clients.authentication_client import AuthenticationClient
 from dsp_tools.clients.permissions_client_live import PermissionsClientLive
-from dsp_tools.commands.get.exceptions import UnknownDOAPException
 from dsp_tools.commands.get.get_permissions_legacy import parse_legacy_doaps
 from dsp_tools.commands.get.models.permissions_models import DoapCategories
+from dsp_tools.commands.get.models.permissions_models import DOAPResult
 from dsp_tools.utils.request_utils import ResponseCodeAndText
 
 
@@ -37,51 +38,52 @@ def get_default_permissions(
     )
     if isinstance(project_doaps, ResponseCodeAndText):
         return fallback_text, None
-    try:
-        default_permissions = _parse_default_permissions(project_doaps)
-        default_permissions_overrule = _parse_default_permissions_overrule(project_doaps, prefixes)
-    except UnknownDOAPException:
-        default_permissions = fallback_text
-        default_permissions_overrule = None
-    return default_permissions, default_permissions_overrule
+    doap_result = _parse_default_permissions(project_doaps)
+    if doap_result.error is not None:
+        return doap_result.error, None
+    default_permissions_overrule = _parse_default_permissions_overrule(project_doaps, prefixes)
+    return doap_result.value, default_permissions_overrule  # type: ignore[return-value]
 
 
-def _parse_default_permissions(project_doaps: list[dict[str, Any]]) -> str:
+def _parse_default_permissions(project_doaps: list[dict[str, Any]]) -> DOAPResult:  # noqa: PLR0911
     """
     First tries to parse legacy DOAPs with multiple groups, then falls back to new-style parsing.
     New-style parsing: If the DOAPs exactly match our definition of public/private, return public/private.
-    Otherwise, raise an exception.
+    Otherwise, return a DOAPResult with an error description.
     """
     # First, try to parse legacy DOAPs (multiple groups: ProjectAdmin, ProjectMember)
     if legacy_result := parse_legacy_doaps(project_doaps):
-        return legacy_result
+        return DOAPResult(value=legacy_result, error=None)
 
     # Fall back to new-style parsing (single ProjectMember group)
     unsupported_groups = ("SystemAdmin", "ProjectAdmin", "Creator", "KnownUser", "UnknownUser")
     if [x for x in project_doaps if x.get("forGroup", "").endswith(unsupported_groups)]:
-        raise UnknownDOAPException("The only supported target group for DOAPs is ProjectMember.")
+        return DOAPResult(value=None, error="The only supported target group for DOAPs is ProjectMember.")
     proj_member_doaps = [x for x in project_doaps if x.get("forGroup", "").endswith("ProjectMember")]
     if len(proj_member_doaps) != 1:
-        raise UnknownDOAPException("There must be exactly 1 DOAP for ProjectMember.")
+        return DOAPResult(value=None, error="There must be exactly 1 DOAP for ProjectMember.")
     perms = proj_member_doaps[0]["hasPermissions"]
     if len(perms) not in [2, 4]:
         err_msg = "The only allowed permissions are 'private' (with 2 elements), and 'limited_view' (with 4 elements)"
-        raise UnknownDOAPException(err_msg)
+        return DOAPResult(value=None, error=err_msg)
     proj_adm_perms = [x for x in perms if x["additionalInformation"].endswith("ProjectAdmin")]
     proj_mem_perms = [x for x in perms if x["additionalInformation"].endswith("ProjectMember")]
     knwn_usr_perms = [x for x in perms if x["additionalInformation"].endswith("KnownUser")]
     unkn_usr_perms = [x for x in perms if x["additionalInformation"].endswith("UnknownUser")]
     if not (len(proj_adm_perms) == len(proj_mem_perms) == 1):
-        raise UnknownDOAPException("There must be always 1 permission for ProjectAdmin and 1 for ProjectMember")
+        err_msg = "There must be always 1 permission for ProjectAdmin and 1 for ProjectMember"
+        return DOAPResult(value=None, error=err_msg)
     if proj_adm_perms[0]["name"] != "CR" or proj_mem_perms[0]["name"] != "D":
-        raise UnknownDOAPException("ProjectAdmin must always have CR and ProjectMember must always have D")
+        return DOAPResult(value=None, error="ProjectAdmin must always have CR and ProjectMember must always have D")
     if len(knwn_usr_perms) == len(unkn_usr_perms) == 0:
-        return "private"
+        return DOAPResult(value="private", error=None)
     if not (len(knwn_usr_perms) == len(unkn_usr_perms) == 1):
-        raise UnknownDOAPException("In case of 'limited_view', there must be 1 for KnownUser and 1 for UnknownUser")
+        return DOAPResult(
+            value=None, error="In case of 'limited_view', there must be 1 for KnownUser and 1 for UnknownUser"
+        )
     if knwn_usr_perms[0]["name"] != "V" or unkn_usr_perms[0]["name"] != "V":
-        raise UnknownDOAPException("In case of 'public', KnownUser and UnknownUser must always have V")
-    return "public"
+        return DOAPResult(value=None, error="In case of 'public', KnownUser and UnknownUser must always have V")
+    return DOAPResult(value="public", error=None)
 
 
 def _parse_default_permissions_overrule(
@@ -89,7 +91,7 @@ def _parse_default_permissions_overrule(
 ) -> dict[str, list[str] | Literal["all"]] | None:
     """
     The DOAPs retrieved from the server are examined if they fit into our system of the overrules.
-    If yes, an overrule object is returned. Otherwise, an exception is raised.
+    If yes, an overrule object is returned. Otherwise, None is returned.
 
     Args:
         project_doaps: DOAPs as retrieved from the server
@@ -98,13 +100,14 @@ def _parse_default_permissions_overrule(
     Returns:
         an overrule object that can be written into the JSON project definition file, in this form:
         "default_permissions_overrule": {"private": [<classes_or_props>], "limited_view": ["all" or <img_classes>]}
-
-    Raises:
-        UnknownDOAPException: if there are DOAPs that do not fit into our system
+        or None if the DOAPs do not fit into our system
     """
     prefixes_knora_base_inverted = _convert_prefixes(prefixes)
     doap_categories = _categorize_doaps(project_doaps)
-    _validate_doap_categories(doap_categories)
+    if doap_categories is None:
+        return None
+    if not _validate_doap_categories(doap_categories):
+        return None
     return _construct_overrule_object(doap_categories, prefixes_knora_base_inverted)
 
 
@@ -126,7 +129,7 @@ def _convert_prefixes(prefixes: dict[str, str]) -> dict[str, str]:
     return prefixes_knora_base_inverted
 
 
-def _categorize_doaps(project_doaps: list[dict[str, Any]]) -> DoapCategories:
+def _categorize_doaps(project_doaps: list[dict[str, Any]]) -> DoapCategories | None:
     """
     The overrule object of the JSON project definition file has 2 categories: private and limited_view.
     - "private" is a list of classes/properties that are private.
@@ -141,11 +144,8 @@ def _categorize_doaps(project_doaps: list[dict[str, Any]]) -> DoapCategories:
     Args:
         project_doaps: the DOAPs as retrieved from the server
 
-    Raises:
-        UnknownDOAPException: if there are DOAPs that do not fit into our system
-
     Returns:
-        a DTO with the categories
+        a DTO with the categories, or None if there are DOAPs that do not fit into our system
     """
     class_doaps = []
     prop_doaps = []
@@ -166,10 +166,8 @@ def _categorize_doaps(project_doaps: list[dict[str, Any]]) -> DoapCategories:
                 other_doaps.append(doap)
     # Only validate other_doaps if there are any
     if other_doaps:
-        try:
-            _parse_default_permissions(other_doaps)
-        except UnknownDOAPException:
-            raise UnknownDOAPException("Found DOAPs that do not fit into our system") from None
+        if _parse_default_permissions(other_doaps).error is not None:
+            return None
     return DoapCategories(
         class_doaps=class_doaps,
         prop_doaps=prop_doaps,
@@ -178,16 +176,19 @@ def _categorize_doaps(project_doaps: list[dict[str, Any]]) -> DoapCategories:
     )
 
 
-def _validate_doap_categories(doap_categories: DoapCategories) -> None:
+def _validate_doap_categories(doap_categories: DoapCategories) -> bool:  # noqa: PLR0911
     for expected_private_doap in doap_categories.class_doaps + doap_categories.prop_doaps:
         perm = sorted(expected_private_doap["hasPermissions"], key=lambda x: x["name"])
         if len(perm) != 2:
-            raise UnknownDOAPException("'private' is defined as CR ProjectAdmin|D ProjectMember")
+            logger.error("'private' is defined as CR ProjectAdmin|D ProjectMember")
+            return False
         CR, D = perm
         if CR["name"] != "CR" or not CR["additionalInformation"].endswith("ProjectAdmin"):
-            raise UnknownDOAPException("'private' is defined as CR ProjectAdmin|D ProjectMember")
+            logger.error("'private' is defined as CR ProjectAdmin|D ProjectMember")
+            return False
         if D["name"] != "D" or not D["additionalInformation"].endswith("ProjectMember"):
-            raise UnknownDOAPException("'private' is defined as CR ProjectAdmin|D ProjectMember")
+            logger.error("'private' is defined as CR ProjectAdmin|D ProjectMember")
+            return False
 
     for expected_limited_view in (
         doap_categories.has_img_all_classes_doaps + doap_categories.has_img_specific_class_doaps
@@ -195,21 +196,28 @@ def _validate_doap_categories(doap_categories: DoapCategories) -> None:
         err_msg = "'limited_view' is defined as CR ProjectAdmin|D ProjectMember|RV KnownUser|RV UnknownUser"
         perm = sorted(expected_limited_view["hasPermissions"], key=lambda x: x["name"])
         if len(perm) != 4:
-            raise UnknownDOAPException(err_msg)
+            logger.error(err_msg)
+            return False
         CR, D, RV1, RV2 = perm
         if CR["name"] != "CR" or not CR["additionalInformation"].endswith("ProjectAdmin"):
-            raise UnknownDOAPException(err_msg)
+            logger.error(err_msg)
+            return False
         if D["name"] != "D" or not D["additionalInformation"].endswith("ProjectMember"):
-            raise UnknownDOAPException(err_msg)
+            logger.error(err_msg)
+            return False
         if RV1["name"] != "RV" or not RV2["additionalInformation"].endswith("nownUser"):
-            raise UnknownDOAPException(err_msg)
+            logger.error(err_msg)
+            return False
         if RV2["name"] != "RV" or not RV2["additionalInformation"].endswith("nownUser"):
-            raise UnknownDOAPException(err_msg)
+            logger.error(err_msg)
+            return False
+
+    return True
 
 
 def _construct_overrule_object(
     doap_categories: DoapCategories, prefixes_knora_base_inverted: dict[str, str]
-) -> dict[str, list[str] | Literal["all"]]:
+) -> dict[str, list[str] | Literal["all"]] | None:
     """
     Construct the final overrules object that can be written into the JSON project definition file.
     To do so, the fully qualified IRIs of the classes/properties must be converted to prefixed IRIs.
@@ -218,11 +226,9 @@ def _construct_overrule_object(
         doap_categories: The categorized DOAPs from the server
         prefixes_knora_base_inverted: lookup from fully qualified IRIs to prefixed IRIs
 
-    Raises:
-        UnknownDOAPException: if the DOAPs do not fit into our system
-
     Returns:
-        the final overrules object that can be written into the JSON project definition file
+        the final overrules object that can be written into the JSON project definition file,
+        or None if the DOAPs do not fit into our system
     """
     privates: list[str] = []
     for class_doap in doap_categories.class_doaps:
@@ -232,9 +238,9 @@ def _construct_overrule_object(
 
     limited_views: list[str] | Literal["all"]
     if len(doap_categories.has_img_all_classes_doaps) > 1:
-        raise UnknownDOAPException("There can only be 1 all-images DOAP for 'hasStillImageFileValue'")
+        return None
     if len(doap_categories.has_img_all_classes_doaps) == 1 and len(doap_categories.has_img_specific_class_doaps) > 0:
-        raise UnknownDOAPException("If there is a DOAP for all images, there cannot be DOAPs for specific img classes")
+        return None
     if len(doap_categories.has_img_all_classes_doaps) == 1:
         limited_views = "all"
     else:

--- a/src/dsp_tools/commands/get/models/permissions_models.py
+++ b/src/dsp_tools/commands/get/models/permissions_models.py
@@ -1,5 +1,16 @@
 from dataclasses import dataclass
 from typing import Any
+from typing import Literal
+
+
+@dataclass
+class DOAPResult:
+    value: Literal["public", "private"] | None  # set on successful parse
+    error: str | None  # set on failure; explanation of what went wrong
+
+    def __post_init__(self) -> None:
+        if (self.value is None) == (self.error is None):
+            raise ValueError("Exactly one of value or error must be set")
 
 
 @dataclass

--- a/test/unittests/commands/get/test_get_permissions.py
+++ b/test/unittests/commands/get/test_get_permissions.py
@@ -3,7 +3,6 @@ from typing import Any
 import pytest
 import regex
 
-from dsp_tools.commands.get.exceptions import UnknownDOAPException
 from dsp_tools.commands.get.get_permissions import _categorize_doaps
 from dsp_tools.commands.get.get_permissions import _construct_overrule_object
 from dsp_tools.commands.get.get_permissions import _convert_prefixes
@@ -98,27 +97,31 @@ def public_perms() -> dict[str, Any]:
 
 
 def test_parse_default_permissions_private(private_perms: dict[str, Any]) -> None:
-    assert _parse_default_permissions([private_perms]) == "private"
+    result = _parse_default_permissions([private_perms])
+    assert result.value == "private"
+    assert result.error is None
 
 
 def test_parse_default_permissions_public(public_perms: dict[str, Any]) -> None:
-    assert _parse_default_permissions([public_perms]) == "public"
+    result = _parse_default_permissions([public_perms])
+    assert result.value == "public"
+    assert result.error is None
 
 
 def test_parse_default_permissions_wrong_target(public_perms: dict[str, Any]) -> None:
     public_perms["forGroup"] = f"{USER_IRI_PREFIX}SystemAdmin"
-    with pytest.raises(UnknownDOAPException, match=regex.escape("supported target group for DOAPs is ProjectMember")):
-        _parse_default_permissions([public_perms])
+    result = _parse_default_permissions([public_perms])
+    assert result.error is not None
+    assert regex.search("supported target group for DOAPs is ProjectMember", result.error)
 
 
 def test_parse_default_permissions_with_creator(public_perms: dict[str, Any]) -> None:
     public_perms["hasPermissions"].append(
         {"additionalInformation": f"{USER_IRI_PREFIX}Creator", "name": "CR", "permissionCode": 16}
     )
-    with pytest.raises(
-        UnknownDOAPException, match=regex.escape("'private' (with 2 elements), and 'limited_view' (with 4 elements)")
-    ):
-        _parse_default_permissions([public_perms])
+    result = _parse_default_permissions([public_perms])
+    assert result.error is not None
+    assert regex.search(r"'private' \(with 2 elements\), and 'limited_view' \(with 4 elements\)", result.error)
 
 
 @pytest.mark.parametrize(
@@ -157,12 +160,14 @@ def test_categorize_doaps_valid_cases(
     img_specific_doap: dict[str, Any],
 ) -> None:
     result = _categorize_doaps([class_doap_private, prop_doap_private, img_all_doap])
+    assert result is not None
     assert result.class_doaps == [class_doap_private]
     assert result.prop_doaps == [prop_doap_private]
     assert result.has_img_all_classes_doaps == [img_all_doap]
     assert result.has_img_specific_class_doaps == []
 
     result2 = _categorize_doaps([class_doap_private, img_specific_doap])
+    assert result2 is not None
     assert result2.class_doaps == [class_doap_private]
     assert result2.prop_doaps == []
     assert result2.has_img_all_classes_doaps == []
@@ -171,6 +176,7 @@ def test_categorize_doaps_valid_cases(
 
 def test_categorize_doaps_empty() -> None:
     result = _categorize_doaps([])
+    assert result is not None
     assert len(result.class_doaps) == 0
     assert len(result.prop_doaps) == 0
     assert len(result.has_img_all_classes_doaps) == 0
@@ -209,8 +215,7 @@ def test_categorize_doaps_empty() -> None:
     ],
 )
 def test_categorize_doaps_invalid_doap(invalid_doap: dict[str, Any]) -> None:
-    with pytest.raises(UnknownDOAPException):
-        _categorize_doaps([invalid_doap])
+    assert _categorize_doaps([invalid_doap]) is None
 
 
 def test_categorize_doaps_mixed_valid_and_invalid(class_doap_private: dict[str, Any]) -> None:
@@ -220,8 +225,7 @@ def test_categorize_doaps_mixed_valid_and_invalid(class_doap_private: dict[str, 
         "forProject": PROJ_IRI,
         "hasPermissions": [],
     }
-    with pytest.raises(UnknownDOAPException):
-        _categorize_doaps([class_doap_private, invalid_doap])
+    assert _categorize_doaps([class_doap_private, invalid_doap]) is None
 
 
 def test_validate_doap_categories_valid_all_images(
@@ -233,7 +237,7 @@ def test_validate_doap_categories_valid_all_images(
         has_img_all_classes_doaps=[img_all_doap],
         has_img_specific_class_doaps=[],
     )
-    _validate_doap_categories(categories)
+    assert _validate_doap_categories(categories)
 
 
 def test_validate_doap_categories_valid_specific_images(
@@ -245,7 +249,7 @@ def test_validate_doap_categories_valid_specific_images(
         has_img_all_classes_doaps=[],
         has_img_specific_class_doaps=[img_specific_doap],
     )
-    _validate_doap_categories(categories)
+    assert _validate_doap_categories(categories)
 
 
 def test_validate_doap_categories_invalid_private_wrong_count() -> None:
@@ -261,8 +265,7 @@ def test_validate_doap_categories_invalid_private_wrong_count() -> None:
         has_img_all_classes_doaps=[],
         has_img_specific_class_doaps=[],
     )
-    with pytest.raises(UnknownDOAPException, match=r"'private' is defined as CR ProjectAdmin\|D ProjectMember"):
-        _validate_doap_categories(categories)
+    assert not _validate_doap_categories(categories)
 
 
 def test_validate_doap_categories_invalid_private_wrong_names() -> None:
@@ -279,8 +282,7 @@ def test_validate_doap_categories_invalid_private_wrong_names() -> None:
         has_img_all_classes_doaps=[],
         has_img_specific_class_doaps=[],
     )
-    with pytest.raises(UnknownDOAPException, match=r"'private' is defined as CR ProjectAdmin\|D ProjectMember"):
-        _validate_doap_categories(categories)
+    assert not _validate_doap_categories(categories)
 
 
 def test_validate_doap_categories_invalid_limited_view_wrong_count() -> None:
@@ -297,11 +299,7 @@ def test_validate_doap_categories_invalid_limited_view_wrong_count() -> None:
         has_img_all_classes_doaps=[img_doap],
         has_img_specific_class_doaps=[],
     )
-    with pytest.raises(
-        UnknownDOAPException,
-        match=r"'limited_view' is defined as CR ProjectAdmin\|D ProjectMember\|RV KnownUser\|RV UnknownUser",
-    ):
-        _validate_doap_categories(categories)
+    assert not _validate_doap_categories(categories)
 
 
 def test_construct_overrule_object_private_only() -> None:
@@ -412,8 +410,7 @@ def test_construct_overrule_object_invalid_multiple_all_images() -> None:
         has_img_all_classes_doaps=[img_doap1, img_doap2],
         has_img_specific_class_doaps=[],
     )
-    with pytest.raises(UnknownDOAPException, match="There can only be 1 all-images DOAP"):
-        _construct_overrule_object(categories, {})
+    assert _construct_overrule_object(categories, {}) is None
 
 
 def test_construct_overrule_object_invalid_mixed_image_types() -> None:
@@ -432,8 +429,7 @@ def test_construct_overrule_object_invalid_mixed_image_types() -> None:
         has_img_all_classes_doaps=[all_img_doap],
         has_img_specific_class_doaps=[specific_img_doap],
     )
-    with pytest.raises(UnknownDOAPException, match="If there is a DOAP for all images, there cannot be DOAPs"):
-        _construct_overrule_object(categories, {})
+    assert _construct_overrule_object(categories, {}) is None
 
 
 @pytest.mark.parametrize(

--- a/test/unittests/commands/get/test_get_permissions_legacy.py
+++ b/test/unittests/commands/get/test_get_permissions_legacy.py
@@ -2,7 +2,6 @@ from typing import Any
 
 import pytest
 
-from dsp_tools.commands.get.exceptions import UnknownDOAPException
 from dsp_tools.commands.get.get_permissions import _parse_default_permissions
 from dsp_tools.commands.get.get_permissions_legacy import parse_legacy_doaps
 
@@ -119,5 +118,5 @@ def test_parse_default_permissions_invalid_legacy_falls_back() -> None:
             {"additionalInformation": f"{USER_IRI_PREFIX}WrongGroup", "name": "CR", "permissionCode": 16},
         ],
     }
-    with pytest.raises(UnknownDOAPException):
-        _parse_default_permissions([invalid_legacy])
+    result = _parse_default_permissions([invalid_legacy])
+    assert result.error is not None


### PR DESCRIPTION
## Summary

- Introduced a `DOAPResult` dataclass (`value: Literal["public", "private"] | None`, `error: str | None`) with a `__post_init__` validator enforcing that exactly one field is set
- `_parse_default_permissions` now returns `DOAPResult` instead of raising `UnknownDOAPException` — the expected-alternative-outcome is explicit in the type
- Internal helpers (`_categorize_doaps`, `_validate_doap_categories`, `_construct_overrule_object`) return `None`/`bool` instead of raising — no more exception-based control flow in the chain
- `get_default_permissions` branches on `doap_result.error is not None` instead of catching `UnknownDOAPException`
- `exceptions.py` (which only contained `UnknownDOAPException`) deleted
- Tests updated to match the new return-value API

Closes DEV-6161

## Test plan

- [x] `pytest test/unittests/commands/get/test_get_permissions.py` — 33 tests pass
- [x] `pytest test/unittests/` — 2319 tests pass
- [x] `ruff check` (as `just lint` runs it) — no new errors
- [x] `ruff format --check` — all files formatted
- [x] `mypy src/dsp_tools/commands/get/` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)