### PR TITLE
chore(dependabot): limit to one open PR at a time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 1
     groups:
       all-dependencies:
         patterns:


### PR DESCRIPTION
## Summary

- Adds `open-pull-requests-limit: 1` to the `uv` ecosystem block in `.github/dependabot.yml`

## Why

Dependabot was creating individual PRs for packages whose new versions were released *after* the weekly grouped PR was already open (e.g. #2261 was the correct grouped PR on Apr 13; #2262 appeared the next day for a single `pytest` patch). This happens because Dependabot does not automatically update an existing open grouped PR when a new version arrives mid-week — it opens a new individual PR instead.

With `open-pull-requests-limit: 1`, Dependabot will not open a second PR while the grouped one is still open. Mid-week updates are queued and included in the next weekly grouped PR after the current one is merged.

The stale individual PRs (#2251, #2259, #2262) were closed as part of this cleanup.

## Reviewer notes

One-line YAML change. No logic or code affected — Dependabot reads this config directly.