### PR TITLE
fix(xmlupload): resolve internal links inside footnote content (DEV-6289)

### DIFF
--- a/src/dsp_tools/commands/xmlupload/richtext_id2iri.py
+++ b/src/dsp_tools/commands/xmlupload/richtext_id2iri.py
@@ -3,6 +3,11 @@ import regex
 from dsp_tools.commands.xmlupload.exceptions import Id2IriReplacementError
 from dsp_tools.commands.xmlupload.iri_resolver import IriResolver
 
+# Inside a `<footnote content="...">` attribute, the nested `<a href="...">` is XML-escaped,
+# so the attribute delimiter around the IRI placeholder can be either `"` or `&quot;`.
+_HREF_QUOTE = r'(?:"|&quot;)'
+_INTERNAL_ID_PATTERN = rf"href={_HREF_QUOTE}IRI:(.*?):IRI{_HREF_QUOTE}"
+
 
 def prepare_richtext_string_for_upload(richtext_str: str, iri_resolver: IriResolver) -> str:
     richtext_str, ids_not_found = replace_ids_if_found(richtext_str, iri_resolver)
@@ -26,11 +31,13 @@ def replace_ids_if_found(richtext_str: str, iri_resolver: IriResolver) -> tuple[
 
 
 def _replace_one_id(txt: str, id_: str, iri: str) -> str:
-    return txt.replace(f'href="IRI:{id_}:IRI"', f'href="{iri}"')
+    txt = txt.replace(f'href="IRI:{id_}:IRI"', f'href="{iri}"')
+    txt = txt.replace(f"href=&quot;IRI:{id_}:IRI&quot;", f"href=&quot;{iri}&quot;")
+    return txt
 
 
 def find_internal_ids(txt: str) -> set[str]:
-    return set(regex.findall(pattern='href="IRI:(.*?):IRI"', string=txt))
+    return set(regex.findall(pattern=_INTERNAL_ID_PATTERN, string=txt))
 
 
 def _richtext_as_xml(richtext_str: str) -> str:

--- a/test/e2e/commands/xmlupload/test_values.py
+++ b/test/e2e/commands/xmlupload/test_values.py
@@ -391,6 +391,13 @@ class TestTextParsing:
         )
         assert returned_str == expected_str
 
+    def test_res_with_internal_link_in_footnote(self, g_text_parsing, onto_iri_9999):
+        target_iri = util_get_res_iri_from_label(g_text_parsing, "target_resource_with_id")
+        prop_iri = URIRef(f"{onto_iri_9999}testRichtext")
+        returned_str = self._util_get_string_value(g_text_parsing, "res_with_internal_link_in_footnote", prop_iri)
+        assert str(target_iri) in returned_str
+        assert "IRI:target_resource_with_id:IRI" not in returned_str
+
     def test_special_characters_in_richtext(self, g_text_parsing, onto_iri_9999):
         prop_iri = URIRef(f"{onto_iri_9999}testRichtext")
         returned_str = self._util_get_string_value(g_text_parsing, "res_richtext_special_characters", prop_iri)

--- a/test/e2e/commands/xmlupload/test_values.py
+++ b/test/e2e/commands/xmlupload/test_values.py
@@ -394,9 +394,12 @@ class TestTextParsing:
     def test_res_with_internal_link_in_footnote(self, g_text_parsing, onto_iri_9999):
         target_iri = util_get_res_iri_from_label(g_text_parsing, "target_resource_with_id")
         prop_iri = URIRef(f"{onto_iri_9999}testRichtext")
+        expected_str = (
+            f'Text <footnote content="Footnote &lt;a class=&quot;salsah-link&quot; '
+            f'href=&quot;{target_iri}&quot;&gt;link&lt;/a&gt;"/> end text'
+        )
         returned_str = self._util_get_string_value(g_text_parsing, "res_with_internal_link_in_footnote", prop_iri)
-        assert str(target_iri) in returned_str
-        assert "IRI:target_resource_with_id:IRI" not in returned_str
+        assert expected_str in returned_str
 
     def test_special_characters_in_richtext(self, g_text_parsing, onto_iri_9999):
         prop_iri = URIRef(f"{onto_iri_9999}testRichtext")

--- a/test/unittests/commands/xmlupload/test_richtext_id2iri.py
+++ b/test/unittests/commands/xmlupload/test_richtext_id2iri.py
@@ -26,6 +26,23 @@ TXT_THREE_LINKS_WITH_IRIS_AND_IDS = (
 
 TXT_NO_LINKS = "Normal text, no links."
 
+TXT_FOOTNOTE_ONE_ID = (
+    'Text <footnote content="See &lt;a class=&quot;salsah-link&quot; '
+    'href=&quot;IRI:r1_id:IRI&quot;&gt;r1_id&lt;/a&gt; for details."/> end text.'
+)
+
+TXT_FOOTNOTE_TWO_IDS = (
+    'Text <footnote content="See &lt;a class=&quot;salsah-link&quot; '
+    "href=&quot;IRI:r1_id:IRI&quot;&gt;r1_id&lt;/a&gt; and &lt;a class=&quot;salsah-link&quot; "
+    'href=&quot;IRI:r2_id:IRI&quot;&gt;r2_id&lt;/a&gt;."/> end text.'
+)
+
+TXT_MIXED_FOOTNOTE_AND_LINK = (
+    'Start <a class="salsah-link" href="IRI:r1_id:IRI">r1_id</a> '
+    '<footnote content="See &lt;a class=&quot;salsah-link&quot; '
+    'href=&quot;IRI:r2_id:IRI&quot;&gt;r2_id&lt;/a&gt;."/> end.'
+)
+
 
 @pytest.fixture
 def iri_resolver() -> IriResolver:
@@ -83,6 +100,35 @@ class TestReplaceIdIfFound:
         assert result == expected
         assert not_found == {"not_in_lookup"}
 
+    def test_footnote_one_id(self, iri_resolver):
+        expected = (
+            'Text <footnote content="See &lt;a class=&quot;salsah-link&quot; '
+            'href=&quot;r1_iri&quot;&gt;r1_id&lt;/a&gt; for details."/> end text.'
+        )
+        result, not_found = replace_ids_if_found(TXT_FOOTNOTE_ONE_ID, iri_resolver)
+        assert result == expected
+        assert not not_found
+
+    def test_footnote_two_ids(self, iri_resolver):
+        expected = (
+            'Text <footnote content="See &lt;a class=&quot;salsah-link&quot; '
+            "href=&quot;r1_iri&quot;&gt;r1_id&lt;/a&gt; and &lt;a class=&quot;salsah-link&quot; "
+            'href=&quot;r2_iri&quot;&gt;r2_id&lt;/a&gt;."/> end text.'
+        )
+        result, not_found = replace_ids_if_found(TXT_FOOTNOTE_TWO_IDS, iri_resolver)
+        assert result == expected
+        assert not not_found
+
+    def test_mixed_footnote_and_link(self, iri_resolver):
+        expected = (
+            'Start <a class="salsah-link" href="r1_iri">r1_id</a> '
+            '<footnote content="See &lt;a class=&quot;salsah-link&quot; '
+            'href=&quot;r2_iri&quot;&gt;r2_id&lt;/a&gt;."/> end.'
+        )
+        result, not_found = replace_ids_if_found(TXT_MIXED_FOOTNOTE_AND_LINK, iri_resolver)
+        assert result == expected
+        assert not not_found
+
 
 class TestReplaceOneId:
     def test_one_link(self):
@@ -124,3 +170,12 @@ class TestFindInternalIDs:
 
     def test_no_links(self):
         assert not find_internal_ids(TXT_NO_LINKS)
+
+    def test_footnote_one_id(self):
+        assert find_internal_ids(TXT_FOOTNOTE_ONE_ID) == {"r1_id"}
+
+    def test_footnote_two_ids(self):
+        assert find_internal_ids(TXT_FOOTNOTE_TWO_IDS) == {"r1_id", "r2_id"}
+
+    def test_mixed_footnote_and_link(self):
+        assert find_internal_ids(TXT_MIXED_FOOTNOTE_AND_LINK) == {"r1_id", "r2_id"}

--- a/testdata/xml-data/parsing-special-characters-in-richtext-9999.xml
+++ b/testdata/xml-data/parsing-special-characters-in-richtext-9999.xml
@@ -155,4 +155,16 @@
         </text-prop>
     </resource>
 
+    <resource label="res_with_internal_link_in_footnote"
+              restype=":ClassWithEverything"
+              id="res_with_internal_link_in_footnote">
+        <text-prop name=":testRichtext">
+            <text encoding="xml">
+                Text
+                <footnote content="Footnote &lt;a class=&quot;salsah-link&quot; href=&quot;IRI:target_resource_with_id:IRI&quot;&gt;link&lt;/a&gt;"/>
+                end text
+            </text>
+        </text-prop>
+    </resource>
+
 </knora>


### PR DESCRIPTION
## Summary

Fixes [DEV-6289](https://linear.app/dasch/issue/DEV-6289/dsp-tools-xmlupload-internal-links-in-footnotes-are-not-resolved).

Internal links inside a `<footnote content="...">` attribute (e.g. `href="IRI:folio.10:IRI"`) were never replaced with their resolved IRIs during xmlupload. Because the footnote's inner `<a>` tag lives inside an XML-attribute value, lxml re-serializes the surrounding `"` as `&quot;`, so the regex `href="IRI:(.*?):IRI"` used by `find_internal_ids` / `_replace_one_id` never matched.

- Extend both functions in `richtext_id2iri.py` to accept either `"` or `&quot;` around the IRI placeholder.
- Add unit tests for footnotes with one id, two ids, and a mixed footnote+plain-link scenario (for `find_internal_ids` and `replace_ids_if_found`).

## Test plan

- [x] `pytest test/unittests/commands/xmlupload/test_richtext_id2iri.py` — 19 passed
- [x] `pytest test/unittests/commands/xmlupload/ test/unittests/utils/test_replace_id_with_iri.py test/unittests/utils/xml_parsing/` — 313 passed
- [x] `just ruff-check`, `just ruff-format-check`, `just mypy` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)