### PR TITLE
feat(migration): add progress spinner during ZIP upload in import phase (DEV-6307)

### DIFF
--- a/src/dsp_tools/commands/migration/import_zip.py
+++ b/src/dsp_tools/commands/migration/import_zip.py
@@ -33,10 +33,29 @@ def import_zip(target_info: ServerInfo, config: MigrationConfig) -> bool:
 
 def execute_import(client: MigrationImportClient, config: MigrationConfig) -> tuple[bool, ImportId]:
     logger.debug("Starting Import of Project")
-    import_id = client.post_import(config.export_savepath)
+    import_id = _upload_zip(client, config)
     write_or_update_reference_json(config.reference_savepath, import_id=import_id)
     logger.info(f"Import ID of project: {import_id.id_}")
     return _check_import_progress(client, import_id), import_id
+
+
+def _upload_zip(client: MigrationImportClient, config: MigrationConfig) -> ImportId:
+    with yaspin(
+        Spinners.bouncingBall,
+        color="light_green",
+        on_color="on_black",
+        attrs=["bold", "blink"],
+    ) as sp:
+        sp.text = "Uploading project"
+        logger.debug("Uploading project ZIP")
+        try:
+            import_id = client.post_import(config.export_savepath)
+        except Exception:
+            sp.fail("✘")
+            raise
+        logger.info("Upload completed.")
+        sp.ok("✔")
+    return import_id
 
 
 def _check_import_progress(

--- a/test/unittests/commands/migration/test_import_zip.py
+++ b/test/unittests/commands/migration/test_import_zip.py
@@ -1,13 +1,9 @@
 from pathlib import Path
 from unittest.mock import MagicMock
-from unittest.mock import patch
-
-import pytest
 
 from dsp_tools.clients.migration_clients import ExportImportStatus
 from dsp_tools.clients.migration_clients import ImportId
 from dsp_tools.commands.migration.import_zip import _check_import_progress
-from dsp_tools.commands.migration.import_zip import _upload_zip
 from dsp_tools.commands.migration.import_zip import execute_import
 from dsp_tools.commands.migration.models import MigrationConfig
 
@@ -32,39 +28,6 @@ class TestExecuteImport:
         success, returned_id = execute_import(client, config)
         assert success is True
         assert returned_id == import_id
-
-
-class TestUploadZip:
-    def test_success_returns_import_id(self, tmp_path: Path) -> None:
-        (tmp_path / f"export-{SHORTCODE}.zip").touch()
-        import_id = ImportId("test-id-123")
-        config = MigrationConfig(
-            shortcode=SHORTCODE,
-            export_savepath=tmp_path / f"export-{SHORTCODE}.zip",
-            reference_savepath=tmp_path / "migration-references-0099.json",
-            keep_local_export=False,
-            skip_assets=False,
-        )
-        client = MagicMock()
-        client.post_import.return_value = import_id
-        with patch("dsp_tools.commands.migration.import_zip.yaspin"):
-            result = _upload_zip(client, config)
-        assert result == import_id
-
-    def test_exception_propagates(self, tmp_path: Path) -> None:
-        (tmp_path / f"export-{SHORTCODE}.zip").touch()
-        config = MigrationConfig(
-            shortcode=SHORTCODE,
-            export_savepath=tmp_path / f"export-{SHORTCODE}.zip",
-            reference_savepath=tmp_path / "migration-references-0099.json",
-            keep_local_export=False,
-            skip_assets=False,
-        )
-        client = MagicMock()
-        client.post_import.side_effect = RuntimeError("upload failed")
-        with patch("dsp_tools.commands.migration.import_zip.yaspin"):
-            with pytest.raises(RuntimeError, match="upload failed"):
-                _upload_zip(client, config)
 
 
 class TestCheckImportProgress:

--- a/test/unittests/commands/migration/test_import_zip.py
+++ b/test/unittests/commands/migration/test_import_zip.py
@@ -1,9 +1,13 @@
 from pathlib import Path
 from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
 
 from dsp_tools.clients.migration_clients import ExportImportStatus
 from dsp_tools.clients.migration_clients import ImportId
 from dsp_tools.commands.migration.import_zip import _check_import_progress
+from dsp_tools.commands.migration.import_zip import _upload_zip
 from dsp_tools.commands.migration.import_zip import execute_import
 from dsp_tools.commands.migration.models import MigrationConfig
 
@@ -28,6 +32,39 @@ class TestExecuteImport:
         success, returned_id = execute_import(client, config)
         assert success is True
         assert returned_id == import_id
+
+
+class TestUploadZip:
+    def test_success_returns_import_id(self, tmp_path: Path) -> None:
+        (tmp_path / f"export-{SHORTCODE}.zip").touch()
+        import_id = ImportId("test-id-123")
+        config = MigrationConfig(
+            shortcode=SHORTCODE,
+            export_savepath=tmp_path / f"export-{SHORTCODE}.zip",
+            reference_savepath=tmp_path / "migration-references-0099.json",
+            keep_local_export=False,
+            skip_assets=False,
+        )
+        client = MagicMock()
+        client.post_import.return_value = import_id
+        with patch("dsp_tools.commands.migration.import_zip.yaspin"):
+            result = _upload_zip(client, config)
+        assert result == import_id
+
+    def test_exception_propagates(self, tmp_path: Path) -> None:
+        (tmp_path / f"export-{SHORTCODE}.zip").touch()
+        config = MigrationConfig(
+            shortcode=SHORTCODE,
+            export_savepath=tmp_path / f"export-{SHORTCODE}.zip",
+            reference_savepath=tmp_path / "migration-references-0099.json",
+            keep_local_export=False,
+            skip_assets=False,
+        )
+        client = MagicMock()
+        client.post_import.side_effect = RuntimeError("upload failed")
+        with patch("dsp_tools.commands.migration.import_zip.yaspin"):
+            with pytest.raises(RuntimeError, match="upload failed"):
+                _upload_zip(client, config)
 
 
 class TestCheckImportProgress:


### PR DESCRIPTION
## Summary

- Adds a `yaspin` spinner with text "Uploading project" during the blocking `POST /v3/projects/{IRI}/imports` call (up to 7200s timeout)
- Extracts a `_upload_zip()` helper following the same pattern as `_execute_download()` in `export_download.py`
- Calls `sp.fail("✘")` on any exception before re-raising, and `sp.ok("✔")` on success

## Test plan

- [x] New `TestUploadZip` class covers success path and exception-propagation path
- [x] Existing `TestExecuteImport` test continues to pass
- [x] All linters pass (`ruff`, `mypy`, `vulture`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)