### PR TITLE
feat(validate-data): prevent resources from linking to themselves (DEV-6323)

### DIFF
--- a/src/dsp_tools/commands/validate_data/mappers.py
+++ b/src/dsp_tools/commands/validate_data/mappers.py
@@ -134,7 +134,6 @@ TRIPLE_OBJECT_TYPE_TO_XSD = {
 
 RESULT_TO_PROBLEM_MAPPER = {
     ViolationType.SEQNUM_IS_PART_OF: ProblemType.GENERIC,
-    ViolationType.UNIQUE_VALUE: ProblemType.DUPLICATE_VALUE,
     ViolationType.VALUE_TYPE: ProblemType.VALUE_TYPE_MISMATCH,
     ViolationType.PATTERN: ProblemType.INPUT_REGEX,
     ViolationType.GENERIC: ProblemType.GENERIC,

--- a/src/dsp_tools/commands/validate_data/models/input_problems.py
+++ b/src/dsp_tools/commands/validate_data/models/input_problems.py
@@ -118,4 +118,3 @@ class ProblemType(StrEnum):
     LINK_TARGET_IS_IRI_OF_PROJECT = "Linked resource is an IRI of the project"
     LINK_TARGET_NOT_FOUND_IN_DB = "Linked resource is an IRI and could not be found in the database."
     INEXISTENT_LINKED_RESOURCE = "Linked Resource does not exist"
-    DUPLICATE_VALUE = "Your input is duplicated"

--- a/src/dsp_tools/commands/validate_data/models/validation.py
+++ b/src/dsp_tools/commands/validate_data/models/validation.py
@@ -94,7 +94,6 @@ class ValidationResult:
 
 class ViolationType(Enum):
     SEQNUM_IS_PART_OF = auto()
-    UNIQUE_VALUE = auto()
     VALUE_TYPE = auto()
     PATTERN = auto()
     GENERIC = auto()

--- a/src/dsp_tools/commands/validate_data/process_validation_report/query_validation_result.py
+++ b/src/dsp_tools/commands/validate_data/process_validation_report/query_validation_result.py
@@ -209,8 +209,6 @@ def _query_one_without_detail(  # noqa:PLR0911 (Too many return statements)
             return _query_for_less_than_or_equal_violation(base_info, results_and_onto, data, msg)
         case DASH.ClosedByTypesConstraintComponent:
             return _query_for_non_existent_cardinality_violation(base_info, results_and_onto, data)
-        case SH.SPARQLConstraintComponent:
-            return _query_for_unique_value_violation(base_info, results_and_onto)
         case DASH.CoExistsWithConstraintComponent:
             return _query_for_coexists_with_violation(base_info, results_and_onto, data, msg)
         case SH.ClassConstraintComponent:
@@ -223,6 +221,7 @@ def _query_one_without_detail(  # noqa:PLR0911 (Too many return statements)
             | SH.MaxInclusiveConstraintComponent
             | DASH.SingleLineConstraintComponent
             | SH.DatatypeConstraintComponent
+            | SH.SPARQLConstraintComponent
         ):
             return _query_general_violation_info(
                 base_info.result_bn, base_info, results_and_onto, ViolationType.GENERIC

--- a/src/dsp_tools/commands/validate_data/process_validation_report/query_validation_result.py
+++ b/src/dsp_tools/commands/validate_data/process_validation_report/query_validation_result.py
@@ -471,21 +471,6 @@ def _query_for_min_cardinality_violation(
     )
 
 
-def _query_for_unique_value_violation(
-    base_info: ValidationResultBaseInfo,
-    results_and_onto: Graph,
-) -> ValidationResult:
-    val = next(results_and_onto.objects(base_info.result_bn, SH.value))
-    return ValidationResult(
-        violation_type=ViolationType.UNIQUE_VALUE,
-        res_iri=base_info.focus_node_iri,
-        res_class=base_info.focus_node_type,
-        severity=base_info.severity,
-        property=base_info.result_path,
-        input_value=val,
-    )
-
-
 def _query_for_coexists_with_violation(
     base_info: ValidationResultBaseInfo, results_and_onto: Graph, data: Graph, message: SubjectObjectTypeAlias
 ) -> ValidationResult:

--- a/src/dsp_tools/commands/validate_data/process_validation_report/reformat_validation_results.py
+++ b/src/dsp_tools/commands/validate_data/process_validation_report/reformat_validation_results.py
@@ -39,7 +39,6 @@ def _reformat_one_validation_result(validation_result: ValidationResult) -> Inpu
             ViolationType.MAX_CARD
             | ViolationType.NON_EXISTING_CARD
             | ViolationType.PATTERN
-            | ViolationType.UNIQUE_VALUE
             | ViolationType.VALUE_TYPE as violation
         ):
             problem = RESULT_TO_PROBLEM_MAPPER[violation]

--- a/src/dsp_tools/resources/validate_data/api-shapes.ttl
+++ b/src/dsp_tools/resources/validate_data/api-shapes.ttl
@@ -22,7 +22,7 @@
 # therefore only the content is validated with the shapes for the resources.
 
 ########################
-# UNIQUE VALUE SHAPE
+# SPARQL SHAPES
 ########################
 
 api-shapes:UniqueValue_Shape
@@ -53,10 +53,11 @@ api-shapes:UniqueValue_Shape
             HAVING (COUNT(?value) > 1)
                     """ ;
                    sh:severity sh:Violation ;
-                   sh:message  "A resource may not have the same property and value more than one time." ;
+                   sh:message  "Your input is used multiple times for this property and resource." ;
                  ] .
 
-api-shapes:ProhibitSelfReferenceInLink_Shape
+
+api-shapes:ProhibitSelfReferenceInLinkValue_Shape
   a              sh:NodeShape ;
   sh:targetClass knora-api:Resource ;
   sh:sparql      [

--- a/src/dsp_tools/resources/validate_data/api-shapes.ttl
+++ b/src/dsp_tools/resources/validate_data/api-shapes.ttl
@@ -56,6 +56,29 @@ api-shapes:UniqueValue_Shape
                    sh:message  "A resource may not have the same property and value more than one time." ;
                  ] .
 
+api-shapes:ProhibitSelfReferenceInLink_Shape
+  a              sh:NodeShape ;
+  sh:targetClass knora-api:Resource ;
+  sh:sparql      [
+                   a          sh:SPARQLConstraint ;
+                   sh:select  """
+        PREFIX rdfs:       <http://www.w3.org/2000/01/rdf-schema#>
+        PREFIX knora-api:  <http://api.knora.org/ontology/knora-api/v2#>
+        PREFIX api-shapes: <http://api.knora.org/ontology/knora-api/shapes/v2#>
+
+            SELECT $this ?path ?value WHERE {
+
+                $this ?path ?valueClass .
+
+                ?valueClass a knora-api:LinkValue ;
+                            api-shapes:linkValueHasTargetID $this .
+
+            }
+                    """ ;
+                   sh:severity sh:Violation ;
+                   sh:message  "A resource may not link to itself." ;
+                 ] .
+
 
 ########################
 # GENERIC RESOURCE SHAPE

--- a/src/dsp_tools/resources/validate_data/api-shapes.ttl
+++ b/src/dsp_tools/resources/validate_data/api-shapes.ttl
@@ -53,7 +53,7 @@ api-shapes:UniqueValue_Shape
             HAVING (COUNT(?value) > 1)
                     """ ;
                    sh:severity sh:Violation ;
-                   sh:message  "Your input is used multiple times for this property and resource." ;
+                   sh:message  "Your input is duplicated." ;
                  ] .
 
 

--- a/test/e2e/commands/validate_data/test_core_violations.py
+++ b/test/e2e/commands/validate_data/test_core_violations.py
@@ -184,7 +184,7 @@ class TestWithReportGraphs:
             ("date_range_wrong_yyyy", ProblemType.GENERIC),
             ("file_value_missing", ProblemType.FILE_VALUE_MISSING),
             ("geoname_not_number", ProblemType.INPUT_REGEX),
-            ("identical_values", ProblemType.DUPLICATE_VALUE),
+            ("identical_values", ProblemType.GENERIC),
             ("iiif_invalid_characters_in_uri", ProblemType.GENERIC),
             ("label_empty", ProblemType.INPUT_REGEX),
             ("label_with_newline", ProblemType.GENERIC),
@@ -484,7 +484,7 @@ def test_reformat_unique_value_violation(authentication) -> None:
     assert not sorted_problems.unexpected_shacl_validation_components
     alphabetically_sorted = sorted(sorted_problems.unique_violations, key=lambda x: str(x.res_id))
     for one_result, expected_id in zip(alphabetically_sorted, expected_ids):
-        assert one_result.problem_type == ProblemType.DUPLICATE_VALUE
+        assert one_result.problem_type == ProblemType.GENERIC
         assert one_result.res_id == expected_id
     assert not _get_validation_status(sorted_problems, is_on_prod=True)
     assert not _get_validation_status(sorted_problems, is_on_prod=False)

--- a/test/e2e/commands/validate_data/test_core_violations.py
+++ b/test/e2e/commands/validate_data/test_core_violations.py
@@ -300,6 +300,7 @@ def test_reformat_content_violation(authentication) -> None:
         ),
         ("label_empty", "rdfs:label", "The label must be a non-empty string without newlines."),
         ("label_with_newline", "rdfs:label", "The label must be a non-empty string without newlines."),
+        ("link_self_reference", "onto:testHasLinkTo", "link_self_reference"),
         ("link_target_non_existent", "onto:testHasLinkTo", "other"),
         (
             "link_target_of_another_project",

--- a/test/e2e/commands/validate_data/test_core_violations.py
+++ b/test/e2e/commands/validate_data/test_core_violations.py
@@ -300,7 +300,7 @@ def test_reformat_content_violation(authentication) -> None:
         ),
         ("label_empty", "rdfs:label", "The label must be a non-empty string without newlines."),
         ("label_with_newline", "rdfs:label", "The label must be a non-empty string without newlines."),
-        ("link_self_reference", "onto:testHasLinkTo", "link_self_reference"),
+        ("link_self_reference", "onto:testHasLinkTo", "A resource may not link to itself."),
         ("link_target_non_existent", "onto:testHasLinkTo", "other"),
         (
             "link_target_of_another_project",

--- a/test/unittests/commands/validate_data/fixtures/validation_result.py
+++ b/test/unittests/commands/validate_data/fixtures/validation_result.py
@@ -841,7 +841,7 @@ def report_unique_value_literal(onto_graph: Graph) -> tuple[Graph, Graph, Valida
 @pytest.fixture
 def extracted_unique_value_literal() -> ValidationResult:
     return ValidationResult(
-        violation_type=ViolationType.UNIQUE_VALUE,
+        violation_type=ViolationType.GENERIC,
         res_iri=DATA.identical_values_valueHas,
         res_class=ONTO.ClassWithEverything,
         property=ONTO.testGeoname,
@@ -886,7 +886,7 @@ def report_unique_value_iri(onto_graph: Graph) -> tuple[Graph, Graph, Validation
 @pytest.fixture
 def extracted_unique_value_iri() -> ValidationResult:
     return ValidationResult(
-        violation_type=ViolationType.UNIQUE_VALUE,
+        violation_type=ViolationType.GENERIC,
         res_iri=DATA.identical_values_LinkValue,
         res_class=ONTO.ClassWithEverything,
         property=ONTO.testHasLinkTo,

--- a/test/unittests/commands/validate_data/test_get_user_validation_message.py
+++ b/test/unittests/commands/validate_data/test_get_user_validation_message.py
@@ -141,12 +141,13 @@ def inexistent_linked_resource() -> InputProblem:
 @pytest.fixture
 def duplicate_value() -> InputProblem:
     return InputProblem(
-        problem_type=ProblemType.DUPLICATE_VALUE,
+        problem_type=ProblemType.GENERIC,
         res_id="res_id",
         res_type="onto:Class",
         prop_name="onto:hasProp",
         severity=Severity.VIOLATION,
         input_value="Text",
+        message="Your input is duplicated.",
     )
 
 
@@ -481,7 +482,7 @@ class TestUserMessages:
         expected = (
             "Resource ID: res_id | Resource Type: onto:Class\n"
             "onto:hasProp\n"
-            "    - Your input is duplicated | Your input: 'Text'"
+            "    - Your input is duplicated. | Your input: 'Text'"
         )
         assert result == expected
 

--- a/test/unittests/commands/validate_data/test_query_validation_result.py
+++ b/test/unittests/commands/validate_data/test_query_validation_result.py
@@ -312,7 +312,7 @@ class TestQueryWithoutDetail:
         res, data, info = report_unique_value_literal
         result = _query_one_without_detail(info, res, data)
         assert isinstance(result, ValidationResult)
-        assert result.violation_type == ViolationType.UNIQUE_VALUE
+        assert result.violation_type == ViolationType.GENERIC
         assert result.res_iri == info.focus_node_iri
         assert result.res_class == info.focus_node_type
         assert result.severity == SH.Violation
@@ -323,7 +323,7 @@ class TestQueryWithoutDetail:
         res, data, info = report_unique_value_iri
         result = _query_one_without_detail(info, res, data)
         assert isinstance(result, ValidationResult)
-        assert result.violation_type == ViolationType.UNIQUE_VALUE
+        assert result.violation_type == ViolationType.GENERIC
         assert result.res_iri == info.focus_node_iri
         assert result.res_class == info.focus_node_type
         assert result.severity == SH.Violation

--- a/test/unittests/commands/validate_data/test_reformat_validation_results.py
+++ b/test/unittests/commands/validate_data/test_reformat_validation_results.py
@@ -97,7 +97,7 @@ class TestReformatResult:
 
     def test_unique_value_literal(self, extracted_unique_value_literal: ValidationResult) -> None:
         result = _reformat_one_validation_result(extracted_unique_value_literal)
-        assert result.problem_type == ProblemType.DUPLICATE_VALUE
+        assert result.problem_type == ProblemType.GENERIC
         assert result.res_id == "identical_values_valueHas"
         assert result.res_type == "onto:ClassWithEverything"
         assert result.prop_name == "onto:testGeoname"
@@ -106,7 +106,7 @@ class TestReformatResult:
 
     def test_unique_value_iri(self, extracted_unique_value_iri: ValidationResult) -> None:
         result = _reformat_one_validation_result(extracted_unique_value_iri)
-        assert result.problem_type == ProblemType.DUPLICATE_VALUE
+        assert result.problem_type == ProblemType.GENERIC
         assert result.res_id == "identical_values_LinkValue"
         assert result.res_type == "onto:ClassWithEverything"
         assert result.prop_name == "onto:testHasLinkTo"

--- a/testdata/validate-data/core_validation/content_violation.xml
+++ b/testdata/validate-data/core_validation/content_violation.xml
@@ -57,7 +57,7 @@
     </resource>
 
     <!-- Link is the resource class itself -->
-    <resource label="Target does not exist" restype=":ClassWithEverything" id="link_self_reference">
+    <resource label="Target is the resource itself" restype=":ClassWithEverything" id="link_self_reference">
         <resptr-prop name=":testHasLinkTo">
             <resptr>link_self_reference</resptr>
         </resptr-prop>

--- a/testdata/validate-data/core_validation/content_violation.xml
+++ b/testdata/validate-data/core_validation/content_violation.xml
@@ -56,6 +56,13 @@
         </resptr-prop>
     </resource>
 
+    <!-- Link is the resource class itself -->
+    <resource label="Target does not exist" restype=":ClassWithEverything" id="link_self_reference">
+        <resptr-prop name=":testHasLinkTo">
+            <resptr>link_self_reference</resptr>
+        </resptr-prop>
+    </resource>
+
     <!-- Link target is not the range class -->
     <resource label="Link Prop" restype=":ClassWithEverything" id="id_9_target"/>
     <resource label="Target not the right class" restype=":ClassWithEverything" id="link_target_wrong_class">


### PR DESCRIPTION
The API does not allow resources to link to themselves in a link value. Stand-off links in text values are permitted.