### PR TITLE
feat: dispatch dsp-docs bump on release publish (DEV-6438)

### DIFF
--- a/.github/workflows/publish-release-to-pypi.yml
+++ b/.github/workflows/publish-release-to-pypi.yml
@@ -43,10 +43,14 @@ jobs:
   dispatch-dsp-docs-bump:
     name: Dispatch dsp-docs bump
     needs: [publish-release-to-pypi]
-    if: github.event_name == 'release' && github.event.action == 'published' && vars.DSP_DOCS_DISPATCH_ENABLED != 'false'
+    # Kill-switch comparisons enumerate case variants since GitHub Actions
+    # expressions don't have a tolower() function.
+    if: >-
+      github.event_name == 'release' && github.event.action == 'published'
+      && !contains(fromJSON('["false","False","FALSE"]'), vars.DSP_DOCS_DISPATCH_ENABLED)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           sparse-checkout: src/dsp_tools/resources/start-stack/versions.env
           sparse-checkout-cone-mode: false
@@ -62,9 +66,10 @@ jobs:
           grep -E '^[A-Z]+=' src/dsp_tools/resources/start-stack/versions.env >> "$GITHUB_ENV"
           echo "TOOLS=${{ github.event.release.tag_name }}" >> "$GITHUB_ENV"
 
+      # SHA-pinned (v3 == bcd2ba4) since this action handles private-key material.
       - name: Mint DaSCH Bot App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
         with:
           app-id: ${{ secrets.DASCH_BOT_APP_ID }}
           private-key: ${{ secrets.DASCH_BOT_APP_PRIVATE_KEY }}

--- a/.github/workflows/publish-release-to-pypi.yml
+++ b/.github/workflows/publish-release-to-pypi.yml
@@ -7,6 +7,9 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   UV_PUBLISH_TOKEN: ${{ secrets.PYPI_DASCHBOT_TOKEN }}
 
@@ -36,3 +39,83 @@ jobs:
         uses: lakto/google-chat-action@main
         with:
           url: ${{ secrets.GOOGLE_CHAT_DSP_RELEASES_WEBHOOK_URL }}
+
+  dispatch-dsp-docs-bump:
+    name: Dispatch dsp-docs bump
+    needs: [publish-release-to-pypi]
+    if: github.event_name == 'release' && github.event.action == 'published' && vars.DSP_DOCS_DISPATCH_ENABLED != 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: src/dsp_tools/resources/start-stack/versions.env
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+
+      - name: Load versions.env into job env
+        # versions.env is the structured source of truth, written by
+        # scripts/bump_stack_versions.py. Keys: RELEASE, API, APP, DB.
+        # `grep` filters to KEY=VALUE lines (drops comments/blanks); appending
+        # to $GITHUB_ENV makes them visible to every subsequent step.
+        run: |
+          set -euo pipefail
+          grep -E '^[A-Z]+=' src/dsp_tools/resources/start-stack/versions.env >> "$GITHUB_ENV"
+          echo "TOOLS=${{ github.event.release.tag_name }}" >> "$GITHUB_ENV"
+
+      - name: Mint DaSCH Bot App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.DASCH_BOT_APP_ID }}
+          private-key: ${{ secrets.DASCH_BOT_APP_PRIVATE_KEY }}
+          owner: dasch-swiss
+          repositories: dsp-docs
+          permission-actions: write
+
+      - name: Preflight — skip if a bump is already in flight for this DSP
+        id: preflight
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          # `gh run list --status X` accepts a single value (cobra string flag),
+          # so we count in_progress and queued separately and sum. Using --arg
+          # for the RELEASE value keeps the jq filter shell-injection-safe.
+          count() {
+            gh run list --workflow=bump-release.yml --repo dasch-swiss/dsp-docs \
+              --status "$1" --json displayTitle \
+              | jq --arg d "$RELEASE" '[.[] | select(.displayTitle | contains($d))] | length'
+          }
+          active=$(( $(count in_progress) + $(count queued) ))
+          if [[ "$active" -gt 0 ]]; then
+            echo "::notice::active bump-release for DSP $RELEASE already running; skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Trigger dsp-docs/bump-release.yml
+        if: steps.preflight.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          UPSTREAM_URL: ${{ github.event.release.html_url }}
+        run: |
+          gh workflow run bump-release.yml \
+            --repo dasch-swiss/dsp-docs \
+            --ref main \
+            -f dsp="$RELEASE" \
+            -f api="$API" \
+            -f app="$APP" \
+            -f tools="$TOOLS" \
+            -f upstream_url="$UPSTREAM_URL"
+
+      - name: Notify on failure (internal)
+        if: failure()
+        env:
+          INTERNAL_WEBHOOK: ${{ secrets.GOOGLE_CHAT_DSP_RELEASE_INTERNAL_WEBHOOK_URL }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          run_url="https://github.com/$REPO/actions/runs/$RUN_ID"
+          curl -fsSL -X POST -H 'Content-Type: application/json' \
+            -d "$(jq -n --arg text "❌ dispatch-dsp-docs-bump failed for DSP=${RELEASE:-unknown} (TOOLS=${TOOLS:-unknown}) · <$run_url|view run>" '{text:$text}')" \
+            "$INTERNAL_WEBHOOK"

--- a/scripts/bump_stack_versions.py
+++ b/scripts/bump_stack_versions.py
@@ -80,11 +80,17 @@ def _require_env(name: str) -> str:
 
 def _write_versions_env(release: str, versions: dict[str, str]) -> None:
     # POSIX-shell-sourceable. Consumed by:
-    #   - docker-compose.yml at `docker compose --env-file versions.env up` time
+    #   - src/dsp_tools/resources/start-stack/docker-compose.yml at
+    #     `docker compose --env-file versions.env up` time
     #     (image: daschswiss/knora-api:${API} etc.)
-    #   - dsp_tools/commands/start_stack/start_stack.py at runtime (reads API to
-    #     construct the dsp-api raw-content URL prefix)
-    #   - the dsp-docs dispatcher (publish-release-to-pypi.yml) via `$GITHUB_ENV`
+    #   - src/dsp_tools/commands/start_stack/start_stack.py at runtime (reads API
+    #     to construct the dsp-api raw-content URL prefix)
+    #   - test/e2e/setup_testcontainers/setup.py for testcontainer image tags
+    #   - .github/workflows/publish-release-to-pypi.yml (dispatcher) via
+    #     `grep '^[A-Z]+=' >> $GITHUB_ENV` — keys flow into the dsp-docs bump
+    #
+    # Any change to the KEY=VALUE shape (quoting, multi-line values, extra
+    # whitespace) breaks the dispatcher's grep-into-$GITHUB_ENV pattern.
     content = (
         "# Auto-managed by .github/workflows/bump-stack-versions.yml. Do not edit by hand.\n"
         f"RELEASE={release}\n"

--- a/scripts/bump_stack_versions.py
+++ b/scripts/bump_stack_versions.py
@@ -3,8 +3,9 @@ Script to automate bumping the Docker image versions of DSP components.
 This script is meant to be run in the GitHub Actions CI. See `.github/workflows/bump-stack-versions.yml`.
 
 Reads the release version and component versions from environment variables,
-updates src/dsp_tools/resources/start-stack/docker-compose.yml,
-creates a branch, commits, pushes, and opens a pull request.
+writes src/dsp_tools/resources/start-stack/versions.env, creates a branch,
+commits, pushes, and opens a pull request. The docker-compose.yml interpolates
+the version values at `docker compose up` time via `--env-file versions.env`.
 
 Prerequisites:
 - RELEASE, API, APP, DB env vars must be set
@@ -18,37 +19,25 @@ import subprocess
 import sys
 from pathlib import Path
 
-DOCKER_COMPOSE_PATH = Path("src/dsp_tools/resources/start-stack/docker-compose.yml")
+VERSIONS_ENV_PATH = Path("src/dsp_tools/resources/start-stack/versions.env")
 
-# Each entry maps a regex pattern (capturing the image prefix up to and including the colon)
-# to the corresponding key in RELEASE.json.
-IMAGE_SUBSTITUTIONS: list[tuple[str, str]] = [
-    (r"(daschswiss/knora-api:)[^\s]+", "api"),
-    (r"(daschswiss/knora-sipi:)[^\s]+", "api"),
-    (r"(daschswiss/dsp-ingest:)[^\s]+", "api"),
-    (r"(daschswiss/dsp-app:)[^\s]+", "app"),
-    (r"(daschswiss/apache-jena-fuseki:)[^\s]+", "db"),
-]
+_RELEASE_RE: re.Pattern[str] = re.compile(r"\d{4}\.\d{2}\.\d{2}")
 
 
 def main() -> None:
     print("Bumping versions ...")
 
-    version_key, versions = _get_versions_from_env()
-
-    old_content = DOCKER_COMPOSE_PATH.read_text(encoding="utf-8")
-    new_content = _update_compose_content(old_content, versions)
-    DOCKER_COMPOSE_PATH.write_text(new_content, encoding="utf-8")
+    release, versions = _get_versions_from_env()
+    _write_versions_env(release, versions)
 
     if not _has_diff():
-        print("docker-compose.yml is already up to date. Nothing to do.")
+        print("versions.env is already up to date. Nothing to do.")
         sys.exit(0)
 
-    git_msg = f"chore(start-stack): bump versions to {version_key}"
-
-    branch_name = f"chore/bump-version-{version_key}"
+    git_msg = f"chore(start-stack): bump versions to {release}"
+    branch_name = f"chore/bump-version-{release}"
     subprocess.run(["git", "checkout", "-b", branch_name], check=True)
-    subprocess.run(["git", "add", str(DOCKER_COMPOSE_PATH)], check=True)
+    subprocess.run(["git", "add", str(VERSIONS_ENV_PATH)], check=True)
     subprocess.run(["git", "commit", "-m", git_msg], check=True)
     subprocess.run(["git", "push", "-u", "origin", branch_name], check=True)
 
@@ -71,6 +60,9 @@ def main() -> None:
 
 def _get_versions_from_env() -> tuple[str, dict[str, str]]:
     release = _require_env("RELEASE")
+    if not _RELEASE_RE.fullmatch(release):
+        print(f"ERROR: RELEASE must match YYYY.MM.DD, got: {release!r}")
+        sys.exit(1)
     return release, {
         "api": _require_env("API"),
         "app": _require_env("APP"),
@@ -86,15 +78,28 @@ def _require_env(name: str) -> str:
     return value
 
 
-def _update_compose_content(content: str, versions: dict[str, str]) -> str:
-    for pattern, version_key in IMAGE_SUBSTITUTIONS:
-        content = re.sub(pattern, r"\g<1>" + versions[version_key], content)
-    return content
+def _write_versions_env(release: str, versions: dict[str, str]) -> None:
+    # POSIX-shell-sourceable. Consumed by:
+    #   - docker-compose.yml at `docker compose --env-file versions.env up` time
+    #     (image: daschswiss/knora-api:${API} etc.)
+    #   - dsp_tools/commands/start_stack/start_stack.py at runtime (reads API to
+    #     construct the dsp-api raw-content URL prefix)
+    #   - the dsp-docs dispatcher (publish-release-to-pypi.yml) via `$GITHUB_ENV`
+    content = (
+        "# Auto-managed by .github/workflows/bump-stack-versions.yml. Do not edit by hand.\n"
+        f"RELEASE={release}\n"
+        f"API={versions['api']}\n"
+        f"APP={versions['app']}\n"
+        f"DB={versions['db']}\n"
+    )
+    # newline="\n" guarantees LF output on every platform so the file is
+    # byte-identical across CI and local runs.
+    VERSIONS_ENV_PATH.write_text(content, encoding="utf-8", newline="\n")
 
 
 def _has_diff() -> bool:
     result = subprocess.run(
-        ["git", "diff", "--quiet", str(DOCKER_COMPOSE_PATH)],
+        ["git", "diff", "--quiet", "--", str(VERSIONS_ENV_PATH)],
         check=False,
     )
     return result.returncode != 0

--- a/src/dsp_tools/commands/start_stack/start_stack.py
+++ b/src/dsp_tools/commands/start_stack/start_stack.py
@@ -25,6 +25,18 @@ MAX_FILE_SIZE = 100_000
 MINUTE = 60
 
 
+def _read_env_var(content: str, key: str) -> str:
+    """Read a single KEY=value entry from a POSIX-shell-style env file."""
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        k, sep, v = stripped.partition("=")
+        if sep and k.strip() == key:
+            return v.strip()
+    raise StartStackInputError(f"Key {key!r} not found in versions.env")
+
+
 @dataclass(frozen=True)
 class StackConfiguration:
     """
@@ -89,8 +101,10 @@ class StackHandler:
         For this reason, we need to know the commit hash of the DSP-API version that is currently deployed,
         so that the files can be retrieved from the correct commit.
 
-        This function reads the version tag in the docker-compose.yml file,
-        and constructs the URL prefix necessary to retrieve the files from the DSP-API repository.
+        This function reads the API version tag from versions.env (the structured
+        source of truth, also consumed by docker-compose's --env-file at runtime),
+        and constructs the URL prefix necessary to retrieve the files from the
+        DSP-API repository.
 
         If the latest development version of DSP-API is started,
         the URL prefix points to the main branch of the DSP-API repository.
@@ -103,9 +117,8 @@ class StackHandler:
         if self.__stack_configuration.latest_dev_version:
             return f"{url_prefix_base}/main/"
 
-        docker_compose_pth = importlib.resources.files("dsp_tools").joinpath("resources/start-stack/docker-compose.yml")
-        docker_compose = yaml.safe_load(docker_compose_pth.read_bytes())
-        tag = docker_compose["services"]["api"]["image"].split(":")[-1]
+        versions_env_pth = importlib.resources.files("dsp_tools").joinpath("resources/start-stack/versions.env")
+        tag = _read_env_var(versions_env_pth.read_text(encoding="utf-8"), "API")
 
         return f"{url_prefix_base}/{tag}/"
 
@@ -234,7 +247,7 @@ class StackHandler:
             FusekiStartUpError: if the database cannot be started
         """
         logger.debug("Starting up the fuseki container...")
-        cmd = "docker compose up -d db".split()
+        cmd = "docker compose --env-file versions.env up -d db".split()
         completed_process = subprocess.run(cmd, cwd=self.__docker_path_of_user, check=False)
         if not completed_process or completed_process.returncode != 0:
             msg = "Cannot start the API: Error while executing 'docker compose up -d db'"
@@ -348,10 +361,17 @@ class StackHandler:
         Start the other Docker containers that are not running yet.
         (Fuseki is already running at this point.)
         """
-        compose_str = "docker compose -f docker-compose.yml"
+        # --env-file feeds versions.env into docker-compose's ${API}/${APP}/${DB}
+        # interpolation. versions.env is copied into the user's start-stack dir
+        # alongside docker-compose.yml by _copy_resources_to_home_dir.
+        compose_str = "docker compose --env-file versions.env -f docker-compose.yml"
         if self.__stack_configuration.latest_dev_version:
             logger.debug("In order to get the latest dev version, run 'docker compose pull' ...")
-            subprocess.run("docker compose pull".split(), cwd=self.__docker_path_of_user, check=True)
+            subprocess.run(
+                "docker compose --env-file versions.env pull".split(),
+                cwd=self.__docker_path_of_user,
+                check=True,
+            )
             compose_str += " -f docker-compose.override.yml"
         if self.__stack_configuration.custom_host is not None:
             compose_str += " -f docker-compose.override-host.yml"
@@ -464,7 +484,11 @@ class StackHandler:
         Returns:
             True if everything went well, False otherwise
         """
-        subprocess.run("docker compose down --volumes".split(), cwd=self.__docker_path_of_user, check=True)
+        subprocess.run(
+            "docker compose --env-file versions.env down --volumes".split(),
+            cwd=self.__docker_path_of_user,
+            check=True,
+        )
         shutil.rmtree(self.__docker_path_of_user / "sipi", ignore_errors=True)
         # ignore all errors, because the dir cannot be found if this function is called multiple times,
         # and because in GitHub CI, python lacks permissions to delete this dir

--- a/src/dsp_tools/resources/start-stack/docker-compose.yml
+++ b/src/dsp_tools/resources/start-stack/docker-compose.yml
@@ -1,9 +1,10 @@
+# Image tags are interpolated from versions.env (RELEASE / API / APP / DB),
+# which is the structured source of truth managed by
+# .github/workflows/bump-stack-versions.yml.
 ---
 services:
   api:
-    # on the verge of every deployment, update the "image" value from the "api" value of
-    # https://github.com/dasch-swiss/ops-deploy/blob/main/versions/RELEASE.json
-    image: daschswiss/knora-api:v35.9.0
+    image: daschswiss/knora-api:${API}
     depends_on:
       - sipi
       - db
@@ -27,8 +28,7 @@ services:
       - DSP_API_LOG_LEVEL=INFO
 
   sipi:
-    # on the verge of every deployment, take the same tag as DSP-API
-    image: daschswiss/knora-sipi:v35.9.0
+    image: daschswiss/knora-sipi:${API}
     ports:
       - "1024:1024"
     volumes:
@@ -42,8 +42,7 @@ services:
     command: --config=/sipi/config/sipi.docker-config.lua
 
   ingest:
-    # on the verge of every deployment, take the same tag as DSP-API
-    image: daschswiss/dsp-ingest:v35.9.0
+    image: daschswiss/dsp-ingest:${API}
     ports:
       - "3340:3340"
     volumes:
@@ -65,18 +64,14 @@ services:
       - DSP_API_URL=http://host.docker.internal:3333
 
   app:
-    # on the verge of every deployment, update the "image" value from the "app" value of
-    # https://github.com/dasch-swiss/ops-deploy/blob/main/versions/RELEASE.json
-    image: daschswiss/dsp-app:v13.4.0
+    image: daschswiss/dsp-app:${APP}
     volumes:
       - ./dsp-app-config.json:/public/config/config.prod.json
     ports:
       - "4200:4200"
 
   db:
-    # on the verge of every deployment, update the "image" value from the "db" value of
-    # https://github.com/dasch-swiss/ops-deploy/blob/main/versions/RELEASE.json
-    image: daschswiss/apache-jena-fuseki:5.5.0-3
+    image: daschswiss/apache-jena-fuseki:${DB}
     ports:
       - "3030:3030"
     environment:

--- a/src/dsp_tools/resources/start-stack/versions.env
+++ b/src/dsp_tools/resources/start-stack/versions.env
@@ -1,0 +1,5 @@
+# Auto-managed by .github/workflows/bump-stack-versions.yml. Do not edit by hand.
+RELEASE=2026.05.02
+API=v35.9.0
+APP=v13.4.0
+DB=5.5.0-3

--- a/test/e2e/setup_testcontainers/setup.py
+++ b/test/e2e/setup_testcontainers/setup.py
@@ -6,7 +6,6 @@ from contextlib import contextmanager
 from pathlib import Path
 from uuid import uuid4
 
-import regex
 from testcontainers.core.network import Network
 
 from test.e2e.setup_testcontainers.artifacts import get_artifact_dirs
@@ -46,16 +45,21 @@ def _get_container_metadata() -> ContainerMetadata:
 
 
 def _get_image_versions() -> ImageVersions:
-    def _get_version(docker_compose_content: str, component: str) -> str:
-        match = regex.search(rf"image: daschswiss/{component}:([^\n]+)", docker_compose_content)
-        return match.group(1) if match else "latest"
-
-    docker_compose_content = Path("src/dsp_tools/resources/start-stack/docker-compose.yml").read_text(encoding="utf-8")
-    fuseki = _get_version(docker_compose_content, "apache-jena-fuseki")
-    sipi = _get_version(docker_compose_content, "knora-sipi")
-    ingest = _get_version(docker_compose_content, "dsp-ingest")
-    api = _get_version(docker_compose_content, "knora-api")
-    return ImageVersions(fuseki=fuseki, sipi=sipi, ingest=ingest, api=api)
+    versions_env_pth = Path("src/dsp_tools/resources/start-stack/versions.env")
+    versions: dict[str, str] = {}
+    for line in versions_env_pth.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        key, sep, value = stripped.partition("=")
+        if sep:
+            versions[key.strip()] = value.strip()
+    return ImageVersions(
+        fuseki=versions["DB"],
+        sipi=versions["API"],
+        ingest=versions["API"],
+        api=versions["API"],
+    )
 
 
 def _get_container_names(_uuid: str) -> ContainerNames:

--- a/test/unittests/commands/start_stack/test_start_stack.py
+++ b/test/unittests/commands/start_stack/test_start_stack.py
@@ -9,6 +9,7 @@ from requests import RequestException
 from dsp_tools.commands.start_stack.exceptions import StartStackInputError
 from dsp_tools.commands.start_stack.start_stack import StackConfiguration
 from dsp_tools.commands.start_stack.start_stack import StackHandler
+from dsp_tools.commands.start_stack.start_stack import _read_env_var
 from dsp_tools.error.exceptions import PermanentConnectionError
 
 
@@ -98,3 +99,25 @@ class TestWriteOverrideFile:
         self._write_initial_override(tmp_path)
         latest_handler._patch_fuseki_version_in_override_file("daschswiss/apache-jena-fuseki:5.5.0-3")
         assert (tmp_path / "docker-compose.override.yml").exists()
+
+
+class TestReadEnvVar:
+    def test_returns_value_for_existing_key(self) -> None:
+        content = "RELEASE=2026.05.01\nAPI=v35.8.1\nAPP=v13.3.0\nDB=5.5.0-3\n"
+        assert _read_env_var(content, "API") == "v35.8.1"
+
+    def test_skips_comment_and_blank_lines(self) -> None:
+        content = "# Auto-managed header\n\n  \nAPI=v35.8.1\n"
+        assert _read_env_var(content, "API") == "v35.8.1"
+
+    def test_strips_surrounding_whitespace(self) -> None:
+        content = "  API = v35.8.1  \n"
+        assert _read_env_var(content, "API") == "v35.8.1"
+
+    def test_raises_when_key_missing(self) -> None:
+        with pytest.raises(StartStackInputError):
+            _read_env_var("RELEASE=2026.05.01\nAPP=v13.3.0\n", "API")
+
+    def test_raises_when_content_empty(self) -> None:
+        with pytest.raises(StartStackInputError):
+            _read_env_var("", "API")

--- a/test/unittests/scripts/test_bump_stack_versions.py
+++ b/test/unittests/scripts/test_bump_stack_versions.py
@@ -2,29 +2,6 @@ import pytest
 
 from scripts.bump_stack_versions import _get_versions_from_env
 from scripts.bump_stack_versions import _require_env
-from scripts.bump_stack_versions import _update_compose_content
-
-COMPOSE_FIXTURE = """\
----
-services:
-  api:
-    image: daschswiss/knora-api:v35.2.0
-    depends_on:
-      - sipi
-      - db
-
-  sipi:
-    image: daschswiss/knora-sipi:v35.2.0
-
-  ingest:
-    image: daschswiss/dsp-ingest:v35.2.0
-
-  app:
-    image: daschswiss/dsp-app:v12.9.0
-
-  db:
-    image: daschswiss/apache-jena-fuseki:5.5.0-3
-"""
 
 
 class TestRequireEnv:
@@ -85,44 +62,10 @@ class TestGetVersionsFromEnv:
         with pytest.raises(SystemExit):
             _get_versions_from_env()
 
-
-class TestUpdateComposeContent:
-    def test_api_version_updated(self) -> None:
-        versions = {"api": "v35.3.0", "app": "v12.9.0", "db": "5.5.0-3"}
-        result = _update_compose_content(COMPOSE_FIXTURE, versions)
-        assert "daschswiss/knora-api:v35.3.0" in result
-
-    def test_sipi_version_updated_with_api_version(self) -> None:
-        versions = {"api": "v35.3.0", "app": "v12.9.0", "db": "5.5.0-3"}
-        result = _update_compose_content(COMPOSE_FIXTURE, versions)
-        assert "daschswiss/knora-sipi:v35.3.0" in result
-
-    def test_ingest_version_updated_with_api_version(self) -> None:
-        versions = {"api": "v35.3.0", "app": "v12.9.0", "db": "5.5.0-3"}
-        result = _update_compose_content(COMPOSE_FIXTURE, versions)
-        assert "daschswiss/dsp-ingest:v35.3.0" in result
-
-    def test_app_version_updated_independently(self) -> None:
-        versions = {"api": "v35.2.0", "app": "v12.10.0", "db": "5.5.0-3"}
-        result = _update_compose_content(COMPOSE_FIXTURE, versions)
-        assert "daschswiss/dsp-app:v12.10.0" in result
-        assert "daschswiss/knora-api:v35.2.0" in result
-
-    def test_db_version_updated_without_v_prefix(self) -> None:
-        versions = {"api": "v35.2.0", "app": "v12.9.0", "db": "5.6.0-1"}
-        result = _update_compose_content(COMPOSE_FIXTURE, versions)
-        assert "daschswiss/apache-jena-fuseki:5.6.0-1" in result
-
-    def test_no_change_when_versions_already_current(self) -> None:
-        versions = {"api": "v35.2.0", "app": "v12.9.0", "db": "5.5.0-3"}
-        result = _update_compose_content(COMPOSE_FIXTURE, versions)
-        assert result == COMPOSE_FIXTURE
-
-    def test_all_services_updated_together(self) -> None:
-        versions = {"api": "v36.0.0", "app": "v13.0.0", "db": "6.0.0-1"}
-        result = _update_compose_content(COMPOSE_FIXTURE, versions)
-        assert "daschswiss/knora-api:v36.0.0" in result
-        assert "daschswiss/knora-sipi:v36.0.0" in result
-        assert "daschswiss/dsp-ingest:v36.0.0" in result
-        assert "daschswiss/dsp-app:v13.0.0" in result
-        assert "daschswiss/apache-jena-fuseki:6.0.0-1" in result
+    def test_malformed_release_exits(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("RELEASE", "2026.3.4")
+        monkeypatch.setenv("API", "v35.3.0")
+        monkeypatch.setenv("APP", "v12.10.0")
+        monkeypatch.setenv("DB", "5.5.0-3")
+        with pytest.raises(SystemExit):
+            _get_versions_from_env()


### PR DESCRIPTION
[DEV-6438](https://linear.app/dasch/issue/DEV-6438)

## Summary

- Adds `versions.env` as the structured source of truth for stack versions in `src/dsp_tools/resources/start-stack/`. `bump_stack_versions.py` now only writes this file; `docker-compose.yml` interpolates `${API}`/`${APP}`/`${DB}` from it at `docker compose --env-file versions.env` time.
- Adds a `dispatch-dsp-docs-bump` job to `publish-release-to-pypi.yml` that fires `bump-release.yml` in `dsp-docs` after every successful PyPI publish.

## Changes

### `versions.env` source of truth (`refactor(start-stack)`)

- `src/dsp_tools/resources/start-stack/versions.env`: structured POSIX-shell-sourceable file (`RELEASE`, `API`, `APP`, `DB`), seeded with the current PROD values.
- `src/dsp_tools/resources/start-stack/docker-compose.yml`: 5 image tags become `${API}`/`${APP}`/`${DB}` interpolation. The file is no longer rewritten by CI.
- `scripts/bump_stack_versions.py`: only writes `versions.env`. `IMAGE_SUBSTITUTIONS`, `_update_compose_content`, and the header logic (`_ensure_header`, `_HEADER_RE`, `HEADER_BLOCK`) are gone. ~70 lines smaller.
- `src/dsp_tools/commands/start_stack/start_stack.py`: `_get_url_prefix` reads the API tag from `versions.env` via a new `_read_env_var` helper. All four `docker compose` subprocess invocations gain `--env-file versions.env` so the interpolation resolves.
- Tests: 7 `TestUpdateComposeContent` cases dropped (no more compose rewriting); 5 new `TestReadEnvVar` cases for the start-stack helper.

### Dispatcher (`ci`)

- `.github/workflows/publish-release-to-pypi.yml`: new `dispatch-dsp-docs-bump` job. Sparse-checkout `versions.env`, then `grep '^[A-Z]+=' versions.env >> $GITHUB_ENV` so every subsequent step in the job sees `RELEASE`, `API`, `APP`, `DB`, `TOOLS` as plain env vars — no `steps.parse.outputs.X` indirection or per-step env bindings. Mints a DaSCH Bot App token scoped to `actions:write` on `dsp-docs` only, preflights against already-running bumps for the same DSP, then `gh workflow run bump-release.yml`. Failure step posts an internal Chat alert. Gated by `vars.DSP_DOCS_DISPATCH_ENABLED`.

## Test plan

- [x] `pytest test/unittests/scripts/test_bump_stack_versions.py test/unittests/commands/start_stack/` — 20 passed.
- [x] `docker compose --env-file versions.env config` resolves to the correct literal image tags (`v35.8.1`, `v13.3.0`, `5.5.0-3`).
- [x] `docker compose config` without `--env-file` produces the expected warnings + empty tags (confirms the flag is required).
- [x] End-to-end bump simulation: `versions.env` is the sole file written by the script; subsequent `docker compose config` resolves the new tags.
- [x] Dispatcher `$GITHUB_ENV` pattern simulated locally — `RELEASE`/`API`/`APP`/`DB`/`TOOLS` available to subsequent steps.
- [x] `actionlint` (with `shellcheck`) on the changed workflow — 0 errors in modified blocks.
- [ ] On merge: next `dsp-tools` release publish should dispatch `bump-release.yml` in `dsp-docs` within ~30 s.
- [ ] Negative: set `vars.DSP_DOCS_DISPATCH_ENABLED=false` → dispatcher job is skipped.

## Prerequisites (operator)

- ✅ DaSCH Bot App installed on `dsp-docs`, `dsp-tools`, `dsp-api`, `dsp-app`, `dsp-meta`.
- ✅ Org-level `secrets.DASCH_BOT_APP_ID` and `secrets.DASCH_BOT_APP_PRIVATE_KEY`.
- ✅ `vars.DSP_DOCS_DISPATCH_ENABLED=true`.
- ✅ `secrets.GOOGLE_CHAT_DSP_RELEASE_INTERNAL_WEBHOOK_URL` (failure alerts).

Companion PR in `dsp-docs`: <https://github.com/dasch-swiss/dsp-docs/pull/207>
