### PR TITLE
chore(bump-stack-versions): use PAT so version-bump PR triggers tests

### DIFF
--- a/.github/workflows/bump-stack-versions.yml
+++ b/.github/workflows/bump-stack-versions.yml
@@ -43,7 +43,12 @@ jobs:
       - name: Bump versions
         run: python scripts/bump_stack_versions.py
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Do not use the default token (GITHUB_TOKEN) for this action,
+          # as any actions triggered by the user of this token will not trigger further actions
+          # (i.e. tests on the version bumping PR).
+          # See https://github.com/googleapis/release-please-action and 
+          # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+          GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
           RELEASE: ${{ inputs.release }}
           API: ${{ inputs.api }}
           APP: ${{ inputs.app }}


### PR DESCRIPTION
## What

Authenticate the `Bump versions` step of `bump-stack-versions.yml` with `DASCHBOT_PAT` instead of the default `GITHUB_TOKEN`.

## Why

In [#2324](https://github.com/dasch-swiss/dsp-tools/pull/2324), the bot's version-bump commit triggered **only the 4 CodeQL checks**, not the test suite. The tests only ran after a human pushed an empty commit — defeating the goal of a hands-off automation.

Root cause: GitHub deliberately suppresses workflow runs for events triggered by the default `GITHUB_TOKEN` ([anti-recursion rule](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow)). The PR is opened by `gh pr create` (in `scripts/bump_stack_versions.py`) using `GITHUB_TOKEN`, so the `pull_request: opened` event was ignored by `tests.yml`, `tests-e2e.yml`, `lint-code.yml`, and `check-docs.yml`. CodeQL ran regardless because it's GitHub's managed default code-scanning setup, not a workflow file.

Events triggered by a PAT *do* start new workflow runs, so the full suite now runs on the first bot commit.

## Notes for reviewer

- This mirrors the existing pattern in `release-please.yml`, which already uses `secrets.DASCHBOT_PAT` for the same reason (and documents it).
- No new secret is needed — `DASCHBOT_PAT` is already in use.
- `scripts/bump_stack_versions.py` is unchanged; `gh` reads `GH_TOKEN` automatically.
- Trigger behaviour can only be verified by dispatching the `workflow_dispatch`-only workflow after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)