### PR TITLE
fix(ci): make Dependabot PRs pass e2e tests without relying on Actions secrets

### DIFF
--- a/.github/workflows/test-python-versions.yml
+++ b/.github/workflows/test-python-versions.yml
@@ -12,7 +12,9 @@ permissions:
 
 env:
   DSP_TOOLS_TESTING: true
-  DSP_USER_PASSWORD: ${{ secrets.DSP_USER_PASSWORD }}
+  # Literal, not a secret: Dependabot PRs cannot read Actions secrets, and this value only creates
+  # a test user on an ephemeral DSP-API stack.
+  DSP_USER_PASSWORD: pw
 
 jobs:
   test-python-3-12:

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -12,7 +12,9 @@ permissions:
 
 env:
   DSP_TOOLS_TESTING: true
-  DSP_USER_PASSWORD: ${{ secrets.DSP_USER_PASSWORD }}
+  # Literal, not a secret: Dependabot PRs cannot read Actions secrets, and this value only creates
+  # a test user on an ephemeral DSP-API stack.
+  DSP_USER_PASSWORD: pw
 
 jobs:
   ingest-xmlupload:


### PR DESCRIPTION
## What

Replace `DSP_USER_PASSWORD: ${{ secrets.DSP_USER_PASSWORD }}` with the literal `DSP_USER_PASSWORD: pw` in `tests-e2e.yml` and `test-python-versions.yml`.

## Why

Dependabot PRs (e.g. #2325) consistently failed two e2e tests with a misleading error:

> `testerProjectAdmin: This user cannot be created as no password is specified and no default password is saved in a .env file.`

Pushing an empty commit "fixed" it — which looked like flakiness but is actually **deterministic**:

- **GitHub runs Dependabot-triggered `pull_request` workflows against a separate _Dependabot secrets_ store, not the _Actions secrets_ store.** `DSP_USER_PASSWORD` lived only in Actions secrets, so on a Dependabot commit `${{ secrets.DSP_USER_PASSWORD }}` resolved to an **empty string**.
- `testerProjectAdmin` in `testdata/json-project/generic-e2e-project-4125.json` has `"password": null`, so `create` falls back to `os.getenv("DSP_USER_PASSWORD")`. With an empty value, `if not pw` is true and the error fires.
- `.env` is gitignored and absent in CI (the setup action only appends the logging flag), so there was no other source for the value.
- An empty commit re-ran the workflow under a **human** actor, which _can_ read Actions secrets — hence the apparent fix.

The value is only used to create a test user on an **ephemeral testcontainer** DSP-API stack and is not genuinely sensitive. Using the literal `pw` (the same value developers use locally) makes Dependabot- and human-triggered runs identical and deterministic, with no dependency on a secret store Dependabot cannot read.

## Reviewer notes

- No source-code change. `read_dotenv_if_exists()` uses `load_dotenv(override=False)`, which is irrelevant here because the env var is now always set to a non-empty value.
- **Optional manual follow-up:** the `DSP_USER_PASSWORD` **Actions** secret is now unused and can be deleted in Settings → Secrets and variables → Actions. Not required for correctness.

## Verification

- `just yamllint` clean on both files.
- Real proof: the next Dependabot PR (or a test PR) should pass the `project` e2e job on its first commit, with no empty commit needed. The two previously failing tests are in `test/e2e/commands/project/test_create.py` and `test/e2e/commands/project/test_get.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)