### PR TITLE
fix(ci): skip uv.lock update when no release PR is open

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,22 +39,26 @@ jobs:
           # iterate over the JSON array with `.[]`, then select PR if title matches condition
           release_pr=$(echo "$pr_data" | jq '.[] | select(.title | startswith("chore: release"))')
 
-          if [[ -z "$release_pr" ]]; then  # -z exits with code 0 if the string has lenght 0
-            echo "No open release-please PR found. Please check the conditions in this script how the PR is searched."
-            exit 1
+          if [[ -z "$release_pr" ]]; then  # -z exits with code 0 if the string has length 0
+            echo "No open release-please PR found — skipping uv.lock update."
+            echo "branch=" >> $GITHUB_OUTPUT
+            exit 0
           fi
 
           branch_name=$(echo "$release_pr" | jq -r '.head.ref')
           echo "branch=$branch_name" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v6
+        if: steps.get_release_pr_branch.outputs.branch != ''
         with:
           fetch-depth: 0
           persist-credentials: false  # Disable default GITHUB_TOKEN credentials
       - name: Install uv
+        if: steps.get_release_pr_branch.outputs.branch != ''
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Update uv.lock and commit it
+        if: steps.get_release_pr_branch.outputs.branch != ''
         env:
           PAT: ${{ secrets.DASCHBOT_PAT }}
         run: |


### PR DESCRIPTION
## Summary

- The `release-please.yml` workflow runs on every push to `main`, including when the release-please PR itself is merged.
- After that merge there is no open release PR, so the \"Get branch\" step previously called `exit 1`, causing a spurious CI failure.
- This PR makes the step succeed gracefully (with an empty `branch` output) when no release PR is found, and guards the three downstream steps (`checkout`, `install uv`, `update uv.lock`) with `if: steps.get_release_pr_branch.outputs.branch != ''` so they are skipped instead of failing.

## What changed

- `.github/workflows/release-please.yml`: replaced `exit 1` with `echo "branch=" >> $GITHUB_OUTPUT && exit 0`, and added `if:` conditions to the three subsequent steps.

## Test plan

- [ ] Trigger the workflow via `workflow_dispatch` while no release PR is open — the run should succeed with the three uv.lock steps shown as skipped.
- [ ] After the next regular PR merge, confirm the release-please PR branch still receives a `uv.lock` commit as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)