### PR TITLE
chore: add .kodus-readiness.yml to skip N/A agent-readiness criteria

### DIFF
--- a/.kodus-readiness.yml
+++ b/.kodus-readiness.yml
@@ -1,0 +1,7 @@
+criteria:
+  # Kodus does not recognise Python/uv tooling — supplemental assessment script handles
+  # linter (ruff), type-checker (mypy strict), lock-file (uv.lock), version-pinned,
+  # test-script (justfile), pre-commit-hooks, dead-code-detection (vulture).
+  # These two criteria genuinely cannot be evaluated from the local filesystem:
+  bundle-analysis: false   # N/A — Python library, no frontend bundle
+  branch-protection: false # Requires GitHub API; checked by assess.py

--- a/.kodus-readiness.yml
+++ b/.kodus-readiness.yml
@@ -1,7 +1,8 @@
+---
 criteria:
   # Kodus does not recognise Python/uv tooling — supplemental assessment script handles
   # linter (ruff), type-checker (mypy strict), lock-file (uv.lock), version-pinned,
   # test-script (justfile), pre-commit-hooks, dead-code-detection (vulture).
   # These two criteria genuinely cannot be evaluated from the local filesystem:
-  bundle-analysis: false   # N/A — Python library, no frontend bundle
-  branch-protection: false # Requires GitHub API; checked by assess.py
+  bundle-analysis: false  # N/A — Python library, no frontend bundle
+  branch-protection: false  # Requires GitHub API; checked by assess.py

--- a/.kodus-readiness.yml
+++ b/.kodus-readiness.yml
@@ -3,6 +3,5 @@ criteria:
   # Kodus does not recognise Python/uv tooling — supplemental assessment script handles
   # linter (ruff), type-checker (mypy strict), lock-file (uv.lock), version-pinned,
   # test-script (justfile), pre-commit-hooks, dead-code-detection (vulture).
-  # These two criteria genuinely cannot be evaluated from the local filesystem:
+  # This criterion genuinely cannot be evaluated from the local filesystem:
   bundle-analysis: false  # N/A — Python library, no frontend bundle
-  branch-protection: false  # Requires GitHub API; checked by assess.py


### PR DESCRIPTION
## Purpose

DaSCH measures the "agent readiness" of its codebases by running Kodus
([`@kodus/agent-readiness`](https://github.com/kodus-ai/agent-readiness)) across
all DSP repositories. The cross-repo run is orchestrated from
[dasch-swiss/dasch-specs](https://github.com/dasch-swiss/dasch-specs)
(`assessments/scripts/assess.py`).

Kodus is tuned for JavaScript/TypeScript projects, so on other stacks it flags
checks it cannot evaluate as failures and distorts the score. `.kodus-readiness.yml`
lets each repo declare its own peculiarities, so that a plain
`npx @kodus/agent-readiness` run scores it fairly and the results stay comparable
across repos.

## This PR

Adds `.kodus-readiness.yml` to dsp-tools (Python library). It skips
`bundle-analysis`, which does not apply — a Python library has no frontend bundle.

Deeper false negatives — checks Kodus cannot detect on a Python/uv stack (ruff,
mypy strict, uv.lock, the justfile test recipe, vulture, dependabot) — are not
addressed here: the config file can only *skip* a criterion, not mark one as
passing. Those remain corrected centrally by `assess.py` in dasch-specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
