### PR TITLE
refactor: rename data_authorship to default_data_authorship

### DIFF
--- a/docs/data-file/xml-data-file.md
+++ b/docs/data-file/xml-data-file.md
@@ -315,7 +315,7 @@ This is **distinct** from:
 
 - the per-file authorship referenced with the same [`authorship-id`](#bitstream) attribute on
   `<bitstream>`/`<iiif-uri>`, which describes the multimedia asset, not the resource record;
-- the project-wide [`data_authorship`](../data-model/json-project/overview.md#data_authorship) default
+- the project-wide [`default_data_authorship`](../data-model/json-project/overview.md#default_data_authorship) default
   set in the project definition file.
 
 

--- a/docs/data-model/json-project/overview.md
+++ b/docs/data-model/json-project/overview.md
@@ -127,7 +127,7 @@ The following fields are optional (if one or more of these fields are not used, 
 - default_permissions_overrule (only if default_permissions = public)
 - data_license
 - data_copyright_holder
-- data_authorship
+- default_data_authorship
 - groups
 - users
 - lists
@@ -229,11 +229,11 @@ for example `http://rdfh.ch/licenses/cc-by-4.0`.
 The copyright holder that applies to every resource record in the project.
 
 
-### `data_authorship`
+### `default_data_authorship`
 
 (optional)
 
-`"data_authorship": ["<string>", "<string>", ...]`
+`"default_data_authorship": ["<string>", "<string>", ...]`
 
 The default authorship that applies to every resource record in the project.
 Each entry is the name of one author.

--- a/src/dsp_tools/commands/create/create_on_server/project.py
+++ b/src/dsp_tools/commands/create/create_on_server/project.py
@@ -34,12 +34,12 @@ def create_project(project: ParsedProjectMetadata, auth: AuthenticationClient, e
 
 
 def _set_resource_side_legal_info(project: ParsedProjectMetadata, client: LegalInfoClient) -> None:
-    if not any([project.data_license, project.data_copyright_holder, project.data_authorship]):
+    if not any([project.data_license, project.data_copyright_holder, project.default_data_authorship]):
         return
     legal_info: dict[str, Any] = {
         "dataLicense": project.data_license,
         "dataCopyrightHolder": project.data_copyright_holder,
-        "dataAuthorship": project.data_authorship,
+        "defaultDataAuthorship": project.default_data_authorship,
     }
     client.set_resource_side_legal_info(legal_info)
 

--- a/src/dsp_tools/commands/create/models/parsed_project.py
+++ b/src/dsp_tools/commands/create/models/parsed_project.py
@@ -29,7 +29,7 @@ class ParsedProjectMetadata:
     enabled_licenses: list[str]
     data_license: str | None
     data_copyright_holder: str | None
-    data_authorship: list[str]
+    default_data_authorship: list[str]
 
 
 class DefaultPermissions(Enum):

--- a/src/dsp_tools/commands/create/parsing/parse_project.py
+++ b/src/dsp_tools/commands/create/parsing/parse_project.py
@@ -62,7 +62,7 @@ def parse_metadata(project_json: dict[str, Any]) -> ParsedProjectMetadata:
         enabled_licenses=project_json.get("enabled_licenses", []),
         data_license=project_json.get("data_license"),
         data_copyright_holder=project_json.get("data_copyright_holder"),
-        data_authorship=project_json.get("data_authorship", []),
+        default_data_authorship=project_json.get("default_data_authorship", []),
     )
 
 

--- a/src/dsp_tools/commands/get/legacy_models/project.py
+++ b/src/dsp_tools/commands/get/legacy_models/project.py
@@ -90,7 +90,7 @@ class Project(Model):
     _enabled_licenses: set[str]
     _data_license: Optional[str]
     _data_copyright_holder: Optional[str]
-    _data_authorship: list[str]
+    _default_data_authorship: list[str]
     _selfjoin: bool
     _status: bool
     _logo: Optional[str]
@@ -108,7 +108,7 @@ class Project(Model):
         enabled_licenses: Optional[set[str]] = None,
         data_license: Optional[str] = None,
         data_copyright_holder: Optional[str] = None,
-        data_authorship: Optional[list[str]] = None,
+        default_data_authorship: Optional[list[str]] = None,
         selfjoin: Optional[bool] = None,
         status: Optional[bool] = None,
         logo: Optional[str] = None,
@@ -127,7 +127,7 @@ class Project(Model):
         :param enabled_licenses: Set of enabled licenses [optional]
         :param data_license: Project-wide data license IRI [optional]
         :param data_copyright_holder: Project-wide data copyright holder [optional]
-        :param data_authorship: Project-wide data authorship [optional]
+        :param default_data_authorship: Project-wide data authorship [optional]
         :param selfjoin: Allow selfjoin [required for CREATE]
         :param status: Status of project (active if True) [required for CREATE]
         :param logo: Path to logo image file [optional] NOT YET USED
@@ -145,7 +145,7 @@ class Project(Model):
         self._enabled_licenses = enabled_licenses or set()
         self._data_license = data_license
         self._data_copyright_holder = data_copyright_holder
-        self._data_authorship = data_authorship or []
+        self._default_data_authorship = default_data_authorship or []
         self._selfjoin = selfjoin
         self._status = status
         self._logo = logo
@@ -276,7 +276,7 @@ class Project(Model):
         enabled_licenses = json_obj.get("enabledLicenses", set())
         data_license = json_obj.get("dataLicense")
         data_copyright_holder = json_obj.get("dataCopyrightHolder")
-        data_authorship = json_obj.get("dataAuthorship", [])
+        default_data_authorship = json_obj.get("defaultDataAuthorship", [])
         selfjoin = json_obj.get("selfjoin")
         if selfjoin is None:
             raise BaseError("Selfjoin is missing")
@@ -296,7 +296,7 @@ class Project(Model):
             enabled_licenses=enabled_licenses,
             data_license=data_license,
             data_copyright_holder=data_copyright_holder,
-            data_authorship=data_authorship,
+            default_data_authorship=default_data_authorship,
             selfjoin=selfjoin,
             status=status,
             logo=logo,
@@ -315,8 +315,8 @@ class Project(Model):
             proj["data_license"] = self._data_license
         if self._data_copyright_holder:
             proj["data_copyright_holder"] = self._data_copyright_holder
-        if self._data_authorship:
-            proj["data_authorship"] = self._data_authorship
+        if self._default_data_authorship:
+            proj["default_data_authorship"] = self._default_data_authorship
         return proj
 
     def create(self) -> Project:

--- a/src/dsp_tools/resources/schema/project.json
+++ b/src/dsp_tools/resources/schema/project.json
@@ -1185,7 +1185,7 @@
                 "data_copyright_holder": {
                     "type": "string"
                 },
-                "data_authorship": {
+                "default_data_authorship": {
                     "type": "array",
                     "minItems": 1,
                     "items": {

--- a/test/e2e/commands/test_create_get_xmlupload.py
+++ b/test/e2e/commands/test_create_get_xmlupload.py
@@ -155,10 +155,10 @@ def _compare_project(
         ret = project_returned["project"].get(field)
         assert orig == ret, f"Field '{field}' is not identical: original='{orig}', returned='{ret}'"
 
-    orig_authorship = project_original["project"]["data_authorship"]
-    ret_authorship = project_returned["project"]["data_authorship"]
+    orig_authorship = project_original["project"]["default_data_authorship"]
+    ret_authorship = project_returned["project"]["default_data_authorship"]
     assert orig_authorship == ret_authorship, (
-        f"Field data_authorship is not identical: original={orig_authorship}, returned={ret_authorship}"
+        f"Field default_data_authorship is not identical: original={orig_authorship}, returned={ret_authorship}"
     )
 
     orig_licenses = set(project_original["project"]["enabled_licenses"])

--- a/test/unittests/clients/test_legal_info_live.py
+++ b/test/unittests/clients/test_legal_info_live.py
@@ -180,7 +180,7 @@ class TestGetEnabledLicenses:
 RESOURCE_SIDE_LEGAL_INFO = {
     "dataLicense": "http://rdfh.ch/licenses/cc-by-4.0",
     "dataCopyrightHolder": "holder",
-    "dataAuthorship": ["author 1", "author 2"],
+    "defaultDataAuthorship": ["author 1", "author 2"],
 }
 
 

--- a/test/unittests/commands/create/create_on_server/test_project.py
+++ b/test/unittests/commands/create/create_on_server/test_project.py
@@ -30,7 +30,7 @@ def parsed_project() -> Mock:
     project.shortname = "name"
     project.data_license = None
     project.data_copyright_holder = None
-    project.data_authorship = []
+    project.default_data_authorship = []
     return project
 
 
@@ -170,7 +170,7 @@ def test_resource_side_legal_info_is_sent_when_set(
 ):
     parsed_project.data_license = "http://rdfh.ch/licenses/cc-by-4.0"
     parsed_project.data_copyright_holder = "holder"
-    parsed_project.data_authorship = ["author 1", "author 2"]
+    parsed_project.default_data_authorship = ["author 1", "author 2"]
     mock_client = Mock()
     mock_client.get_project_iri.side_effect = ProjectNotFoundError("Project not found")
     mock_client.post_new_project.return_value = NEW_PROJECT_IRI
@@ -187,7 +187,7 @@ def test_resource_side_legal_info_is_sent_when_set(
         {
             "dataLicense": "http://rdfh.ch/licenses/cc-by-4.0",
             "dataCopyrightHolder": "holder",
-            "dataAuthorship": ["author 1", "author 2"],
+            "defaultDataAuthorship": ["author 1", "author 2"],
         },
     )
 

--- a/test/unittests/commands/create/serialisation/test_project.py
+++ b/test/unittests/commands/create/serialisation/test_project.py
@@ -59,7 +59,7 @@ class TestSerialiseProject:
             enabled_licenses=["license"],
             data_license=None,
             data_copyright_holder=None,
-            data_authorship=[],
+            default_data_authorship=[],
         )
         expected = {
             "shortcode": "0001",
@@ -86,7 +86,7 @@ class TestSerialiseProject:
             enabled_licenses=["license"],
             data_license="http://rdfh.ch/licenses/cc-by-4.0",
             data_copyright_holder="DaSCH",
-            data_authorship=["Author One", "Author Two"],
+            default_data_authorship=["Author One", "Author Two"],
         )
         expected = {
             "shortcode": "0001",
@@ -111,7 +111,7 @@ class TestSerialiseProject:
             enabled_licenses=[],
             data_license=None,
             data_copyright_holder=None,
-            data_authorship=[],
+            default_data_authorship=[],
         )
         expected = {
             "shortcode": "0001",

--- a/test/unittests/commands/get/test_project_legacy.py
+++ b/test/unittests/commands/get/test_project_legacy.py
@@ -24,31 +24,31 @@ class TestDataSideLegalInfo:
         json_obj = _base_json_obj() | {
             "dataLicense": "http://rdfh.ch/licenses/cc-by-4.0",
             "dataCopyrightHolder": "The Holder",
-            "dataAuthorship": ["Author One", "Author Two"],
+            "defaultDataAuthorship": ["Author One", "Author Two"],
         }
         project = Project.fromJsonObj(Mock(), json_obj)
         result = project.createDefinitionFileObj()
         assert result["data_license"] == "http://rdfh.ch/licenses/cc-by-4.0"
         assert result["data_copyright_holder"] == "The Holder"
-        assert result["data_authorship"] == ["Author One", "Author Two"]
+        assert result["default_data_authorship"] == ["Author One", "Author Two"]
 
     def test_from_json_obj_without_legal_fields(self) -> None:
         project = Project.fromJsonObj(Mock(), _base_json_obj())
         result = project.createDefinitionFileObj()
         assert "data_license" not in result
         assert "data_copyright_holder" not in result
-        assert "data_authorship" not in result
+        assert "default_data_authorship" not in result
 
     def test_create_definition_file_obj_omits_empty_authorship(self) -> None:
         json_obj = _base_json_obj() | {
             "dataLicense": "http://rdfh.ch/licenses/cc-by-4.0",
-            "dataAuthorship": [],
+            "defaultDataAuthorship": [],
         }
         project = Project.fromJsonObj(Mock(), json_obj)
         result = project.createDefinitionFileObj()
         assert result["data_license"] == "http://rdfh.ch/licenses/cc-by-4.0"
         assert "data_copyright_holder" not in result
-        assert "data_authorship" not in result
+        assert "default_data_authorship" not in result
 
 
 if __name__ == "__main__":

--- a/testdata/json-project/systematic-project-4123.json
+++ b/testdata/json-project/systematic-project-4123.json
@@ -25,7 +25,7 @@
         ],
         "data_license": "http://rdfh.ch/licenses/cc-by-4.0",
         "data_copyright_holder": "DaSCH",
-        "data_authorship": [
+        "default_data_authorship": [
             "Default Author One",
             "Default Author Two"
         ],


### PR DESCRIPTION
## Summary

Stacked on #2350 (merges into `feature/dev-6666-tools-resource-side-legal`). Follow-up to the review thread https://github.com/dasch-swiss/dsp-tools/pull/2350#discussion_r3504039497: the project-level authorship is a *default* that per-resource authorship overrides, so its name should say so — consistent with the `default_permissions` precedent.

- Project JSON field: `data_authorship` → `default_data_authorship` (schema, parsing, create, get, docs, test data).
- API payload key: `dataAuthorship` → `defaultDataAuthorship`, matching the dsp-api rename in dasch-swiss/dsp-api#4174.
- `data_license` / `data_copyright_holder` intentionally stay as-is: they are project-wide and cannot be overridden per resource, so they are not defaults.
- The per-resource `authorship-id` mechanism (`xmlupload`) is untouched.

## Test plan

- `pytest test/unittests`: 2598 passed.
- The e2e round-trip `test_get_project` in `test/e2e/commands/test_create_get_xmlupload.py` covers create→get of the renamed field once a dsp-api image with #4174 is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013iLHUkaKhAacsGLiNdem55