### PR TITLE
feat(xmllib): support resource-record authorship on Resource (DEV-6666)

### DIFF
--- a/docs/xmllib-docs/overview.md
+++ b/docs/xmllib-docs/overview.md
@@ -66,6 +66,10 @@ resource = xmllib.Resource.create_new(
 This is distinct from the authorship of a file (see [below](#adding-a-file-to-a-resource)),
 which describes the multimedia asset, not the resource record.
 
+If your project defines a default authorship, this default is not applied to your data automatically:
+it only serves as the value that DSP-APP proposes when a resource is created manually in the web interface.
+A resource record has an authorship only if you set it explicitly with `authorship`, as shown above.
+
 ### Adding Values to a Resource
 
 Once you created a `Resource` you can add values to it.

--- a/docs/xmllib-docs/overview.md
+++ b/docs/xmllib-docs/overview.md
@@ -50,6 +50,22 @@ resource = xmllib.Resource.create_new(
 )
 ```
 
+### Setting the Authorship of a Resource
+
+You can state who authored the resource record itself, i.e. the data describing the object:
+
+```python
+resource = xmllib.Resource.create_new(
+    res_id="general_resource",
+    restype=":ResourceType",
+    label="Title in the DSP-APP",
+    authorship=["Minnie Mouse"],
+)
+```
+
+This is distinct from the authorship of a file (see [below](#adding-a-file-to-a-resource)),
+which describes the multimedia asset, not the resource record.
+
 ### Adding Values to a Resource
 
 Once you created a `Resource` you can add values to it.

--- a/src/dsp_tools/xmllib/internal/input_converters.py
+++ b/src/dsp_tools/xmllib/internal/input_converters.py
@@ -68,6 +68,44 @@ def check_and_fix_is_non_empty_string(
         return ""
 
 
+def check_and_fix_authorship_input(authorship: Any, res_id: str, value_field: str) -> tuple[str, ...] | None:
+    """
+    Checks the authorship input and converts it into a sorted, deduplicated tuple of non-empty strings.
+    Emits warnings and returns None if the input is empty.
+
+    Args:
+        authorship: input authorship collection
+        res_id: resource ID
+        value_field: field to reference in warnings
+
+    Returns:
+        The authors as a sorted tuple, or None if the input is empty.
+    """
+    if authorship is None:
+        return None
+    if not is_nonempty_value_internal(authorship):
+        emit_xmllib_input_type_mismatch_warning(
+            expected_type="list of authorship strings",
+            value=authorship,
+            res_id=res_id,
+            value_field=value_field,
+        )
+        return None
+    fixed_authors = set(check_and_fix_collection_input(authorship, value_field, res_id))
+    fixed_authors_list = [
+        check_and_fix_is_non_empty_string(
+            value=x,
+            res_id=res_id,
+            value_field=value_field,
+        )
+        for x in fixed_authors
+    ]
+    authors = tuple(sorted(fixed_authors_list))
+    if len(authors) == 0:
+        return None
+    return authors
+
+
 def check_and_fix_collection_input(value: Any, prop_name: str, res_id: str) -> list[Any]:
     """
     To allow varied input but ensure consistent typing internally, collections are converted.

--- a/src/dsp_tools/xmllib/internal/serialise_resource.py
+++ b/src/dsp_tools/xmllib/internal/serialise_resource.py
@@ -71,6 +71,8 @@ def _serialise_one_resource(res: AnyResource, authorship_lookup: AuthorshipLooku
 def _serialise_generic_resource(res: Resource, authorship_lookup: AuthorshipLookup) -> etree._Element:
     ele = _make_generic_resource_element(res, "resource")
     ele.attrib["restype"] = res.restype
+    if res.authorship and (resource_auth_id := authorship_lookup.get_id(res.authorship)):
+        ele.attrib["authorship-id"] = resource_auth_id
     if res.file_value:
         auth_id = authorship_lookup.get_id(res.file_value.metadata.authorship)
         ele.append(serialise_file_value(res.file_value, auth_id))

--- a/src/dsp_tools/xmllib/models/internal/file_values.py
+++ b/src/dsp_tools/xmllib/models/internal/file_values.py
@@ -9,7 +9,7 @@ from dsp_tools.utils.data_formats.uri_util import is_iiif_uri
 from dsp_tools.xmllib.internal.checkers import check_and_warn_if_a_string_contains_a_potentially_empty_value
 from dsp_tools.xmllib.internal.checkers import check_and_warn_potentially_empty_string
 from dsp_tools.xmllib.internal.checkers import is_nonempty_value_internal
-from dsp_tools.xmllib.internal.input_converters import check_and_fix_collection_input
+from dsp_tools.xmllib.internal.input_converters import check_and_fix_authorship_input
 from dsp_tools.xmllib.internal.input_converters import check_and_fix_is_non_empty_string
 from dsp_tools.xmllib.internal.xmllib_warnings import MessageInfo
 from dsp_tools.xmllib.internal.xmllib_warnings_util import emit_xmllib_input_type_mismatch_warning
@@ -75,32 +75,7 @@ class Metadata:
                 res_id=resource_id,
                 value_field="copyright_holder (bistream/iiif-uri)",
             )
-        if authorship is not None:
-            if not is_nonempty_value_internal(authorship):
-                emit_xmllib_input_type_mismatch_warning(
-                    expected_type="list of authorship strings",
-                    value=authorship,
-                    res_id=resource_id,
-                    value_field="authorship (bistream/iiif-uri)",
-                )
-                authors = None
-            else:
-                fixed_authors = set(
-                    check_and_fix_collection_input(authorship, "authorship (bistream/iiif-uri)", resource_id)
-                )
-                fixed_authors_list = [
-                    check_and_fix_is_non_empty_string(
-                        value=x,
-                        res_id=resource_id,
-                        value_field="authorship (bistream/iiif-uri)",
-                    )
-                    for x in fixed_authors
-                ]
-                authors = tuple(sorted(fixed_authors_list))
-                if len(authors) == 0:
-                    authors = None
-        else:
-            authors = None
+        authors = check_and_fix_authorship_input(authorship, resource_id, "authorship (bistream/iiif-uri)")
         return cls(
             license=lic_,
             copyright_holder=copyright_holder,

--- a/src/dsp_tools/xmllib/models/internal/file_values.py
+++ b/src/dsp_tools/xmllib/models/internal/file_values.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
 
+from dsp_tools.error.exceptions import UnreachableCodeError
 from dsp_tools.utils.data_formats.uri_util import is_iiif_uri
 from dsp_tools.xmllib.internal.checkers import check_and_warn_if_a_string_contains_a_potentially_empty_value
 from dsp_tools.xmllib.internal.checkers import check_and_warn_potentially_empty_string
@@ -26,9 +27,8 @@ class AuthorshipLookup:
     def get_id(self, authors: tuple[str, ...] | None) -> str | None:
         if authors is None:
             return None
-        if not (found := self.lookup.get(authors)):
-            emit_xmllib_input_warning(MessageInfo(f"The input authors {authors} are not defined in the look-up."))
-            return " / ".join([str(x) for x in authors])
+        if (found := self.lookup.get(authors)) is None:
+            raise UnreachableCodeError(f"The authors {authors} are not defined in the look-up.")
         return found
 
 

--- a/src/dsp_tools/xmllib/models/res.py
+++ b/src/dsp_tools/xmllib/models/res.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from dsp_tools.xmllib.internal.checkers import check_raise_if_input_value_for_value_order_is_incorrect
+from dsp_tools.xmllib.internal.input_converters import check_and_fix_authorship_input
 from dsp_tools.xmllib.internal.input_converters import check_and_fix_collection_input
 from dsp_tools.xmllib.internal.input_converters import check_and_fix_is_non_empty_string
 from dsp_tools.xmllib.internal.xmllib_warnings import MessageInfo
@@ -49,6 +50,7 @@ class Resource:
     permissions: Permissions = Permissions.PROJECT_SPECIFIC_PERMISSIONS
     file_value: AbstractFileValue | None = None
     migration_metadata: MigrationMetadata | None = None
+    authorship: tuple[str, ...] | None = None
 
     @staticmethod
     def create_new(
@@ -56,6 +58,7 @@ class Resource:
         restype: str,
         label: str,
         permissions: Permissions = Permissions.PROJECT_SPECIFIC_PERMISSIONS,
+        authorship: list[str] | None = None,
     ) -> Resource:
         """
         Create a new resource.
@@ -69,6 +72,9 @@ class Resource:
             restype: resource type
             label: resource label
             permissions: optional permissions of this resource
+            authorship: optional authorship of the resource record itself,
+                i.e. the (natural) person(s) who authored the data.
+                This is distinct from the authorship of a file, which is set with `add_file` or `add_iiif_uri`.
 
         Returns:
             Resource
@@ -91,6 +97,16 @@ class Resource:
                 permissions=xmllib.Permissions.PRIVATE,
             )
             ```
+
+            ```python
+            # resource with authorship of the resource record
+            resource = xmllib.Resource.create_new(
+                res_id="ID",
+                restype=":ResourceType",
+                label="label",
+                authorship=["Kitty Meow"],
+            )
+            ```
         """
         if not is_valid_resource_id(res_id):
             res_id = str(res_id)
@@ -103,12 +119,14 @@ class Resource:
                 expected_type="resource type", value=restype, res_id=res_id, value_field="restype"
             )
         lbl = check_and_fix_is_non_empty_string(value=label, res_id=res_id, value_field="label")
+        authors = check_and_fix_authorship_input(authorship, res_id, "authorship (resource)")
 
         return Resource(
             res_id=res_id,
             restype=restype,
             label=lbl,
             permissions=permissions,
+            authorship=authors,
         )
 
     #######################

--- a/src/dsp_tools/xmllib/models/root.py
+++ b/src/dsp_tools/xmllib/models/root.py
@@ -318,6 +318,7 @@ def _make_authorship_lookup(resources: list[AnyResource]) -> AuthorshipLookup:
     filtered_resources = [x for x in resources if isinstance(x, Resource)]
     file_vals = [x.file_value for x in filtered_resources if x.file_value]
     authors = {x.metadata.authorship for x in file_vals if x.metadata.authorship}
+    authors.update(x.authorship for x in filtered_resources if x.authorship)
     sorted_authors = sorted(authors)
     env_var = str(os.getenv("XMLLIB_AUTHORSHIP_ID_WITH_INTEGERS")).lower()
     if env_var == "true":

--- a/test/unittests/xmllib/internal/test_serialise_resource.py
+++ b/test/unittests/xmllib/internal/test_serialise_resource.py
@@ -57,6 +57,28 @@ class TestResource:
         )
         assert serialised == expected
 
+    def test_resource_authorship(self) -> None:
+        res = Resource.create_new("id", ":Type", "lbl", authorship=["one", "one2"])
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            result = _serialise_one_resource(res, AUTHOR_LOOKUP)
+            assert len(caught_warnings) == 0
+        expected = (
+            b'<resource xmlns="https://dasch.swiss/schema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" '
+            b'label="lbl" id="id" restype=":Type" authorship-id="authorship_1"/>'
+        )
+        assert etree.tostring(result) == expected
+
+    def test_resource_authorship_unknown_author(self) -> None:
+        res = Resource.create_new("id", ":Type", "lbl", authorship=["unknown"])
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            result = _serialise_one_resource(res, AUTHOR_LOOKUP)
+            assert len(caught_warnings) == 1
+        expected = (
+            b'<resource xmlns="https://dasch.swiss/schema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" '
+            b'label="lbl" id="id" restype=":Type" authorship-id="unknown"/>'
+        )
+        assert etree.tostring(result) == expected
+
     def test_serialise_no_warnings(self) -> None:
         res = Resource.create_new("id", ":Type", "lbl").add_file(
             "file.jpg", LicenseRecommended.DSP.UNKNOWN, "copy", ["one", "one2"]

--- a/test/unittests/xmllib/internal/test_serialise_resource.py
+++ b/test/unittests/xmllib/internal/test_serialise_resource.py
@@ -4,6 +4,7 @@ import pytest
 import regex
 from lxml import etree
 
+from dsp_tools.error.exceptions import UnreachableCodeError
 from dsp_tools.xmllib.internal.serialise_resource import _serialise_one_resource
 from dsp_tools.xmllib.models.dsp_base_resources import LinkResource
 from dsp_tools.xmllib.models.dsp_base_resources import RegionResource
@@ -68,16 +69,10 @@ class TestResource:
         )
         assert etree.tostring(result) == expected
 
-    def test_resource_authorship_unknown_author(self) -> None:
+    def test_resource_authorship_not_in_lookup(self) -> None:
         res = Resource.create_new("id", ":Type", "lbl", authorship=["unknown"])
-        with warnings.catch_warnings(record=True) as caught_warnings:
-            result = _serialise_one_resource(res, AUTHOR_LOOKUP)
-            assert len(caught_warnings) == 1
-        expected = (
-            b'<resource xmlns="https://dasch.swiss/schema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" '
-            b'label="lbl" id="id" restype=":Type" authorship-id="unknown"/>'
-        )
-        assert etree.tostring(result) == expected
+        with pytest.raises(UnreachableCodeError):
+            _serialise_one_resource(res, AUTHOR_LOOKUP)
 
     def test_serialise_no_warnings(self) -> None:
         res = Resource.create_new("id", ":Type", "lbl").add_file(
@@ -99,34 +94,24 @@ class TestResource:
         )
         assert etree.tostring(result) == expected
 
-    def test_file_value_unknown_author(self) -> None:
+    def test_file_value_author_not_in_lookup(self) -> None:
         res = Resource.create_new("id", ":Type", "lbl").add_file(
             "file.jpg", LicenseRecommended.DSP.UNKNOWN, "copy", ["unknown"]
         )
-        with warnings.catch_warnings(record=True) as caught_warnings:
-            result = _serialise_one_resource(res, AUTHOR_LOOKUP)
-            assert len(caught_warnings) == 1
-        expected = (
-            b'<resource xmlns="https://dasch.swiss/schema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" '
-            b'label="lbl" id="id" restype=":Type">'
-            b'<bitstream license="http://rdfh.ch/licenses/unknown" copyright-holder="copy" authorship-id="unknown">'
-            b"file.jpg"
-            b"</bitstream>"
-            b"</resource>"
-        )
-        assert etree.tostring(result) == expected
+        with pytest.raises(UnreachableCodeError):
+            _serialise_one_resource(res, AUTHOR_LOOKUP)
 
     def test_file_value_other_license(self) -> None:
         res = Resource.create_new("id", ":Type", "lbl").add_file(
-            "file.jpg", LicenseOther.Various.BORIS_STANDARD, "copy", ["unknown"]
+            "file.jpg", LicenseOther.Various.BORIS_STANDARD, "copy", ["one", "one2"]
         )
         with warnings.catch_warnings(record=True) as caught_warnings:
             result = _serialise_one_resource(res, AUTHOR_LOOKUP)
-            assert len(caught_warnings) == 1
+            assert len(caught_warnings) == 0
         expected = (
             b'<resource xmlns="https://dasch.swiss/schema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" '
             b'label="lbl" id="id" restype=":Type">'
-            b'<bitstream license="http://rdfh.ch/licenses/boris" copyright-holder="copy" authorship-id="unknown">'
+            b'<bitstream license="http://rdfh.ch/licenses/boris" copyright-holder="copy" authorship-id="authorship_1">'
             b"file.jpg"
             b"</bitstream>"
             b"</resource>"

--- a/test/unittests/xmllib/models/test_resource.py
+++ b/test/unittests/xmllib/models/test_resource.py
@@ -67,6 +67,26 @@ class TestCreateNewResource:
             res = Resource.create_new("res_id", "restype", pd.NA)  # type: ignore[arg-type]
         assert res.label == ""
 
+    def test_no_authorship(self):
+        res = Resource.create_new("res_id", "restype", "label")
+        assert res.authorship is None
+
+    def test_authorship(self):
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            res = Resource.create_new("res_id", "restype", "label", authorship=["auth2", "auth1", "auth1"])
+            assert len(caught_warnings) == 0
+        assert res.authorship == ("auth1", "auth2")
+
+    def test_authorship_with_empty_string(self):
+        with pytest.warns(XmllibInputWarning):
+            res = Resource.create_new("res_id", "restype", "label", authorship=[""])
+        assert res.authorship is None
+
+    def test_authorship_with_empty_list(self):
+        with pytest.warns(XmllibInputInfo):
+            res = Resource.create_new("res_id", "restype", "label", authorship=[])
+        assert res.authorship is None
+
 
 class TestAddValues:
     def test_add_bool(self) -> None:

--- a/test/unittests/xmllib/models/test_root.py
+++ b/test/unittests/xmllib/models/test_root.py
@@ -1,6 +1,6 @@
 # mypy: disable-error-code="comparison-overlap"
-import importlib.resources
 import warnings
+from pathlib import Path
 
 import pytest
 import regex
@@ -416,8 +416,8 @@ def test_serialise_resource_authorship_is_xsd_valid() -> None:
     resource_ele = next(serialised.iterdescendants(tag=f"{DASCH_SCHEMA}resource"))
     bitstream_ele = next(serialised.iterdescendants(tag=f"{DASCH_SCHEMA}bitstream"))
     assert resource_ele.attrib["authorship-id"] == bitstream_ele.attrib["authorship-id"]
-    schema_res = importlib.resources.files("dsp_tools").joinpath("resources/schema/data.xsd")
-    with schema_res.open(encoding="utf-8") as schema_file:
+    schema_path = Path("src/dsp_tools/resources/schema/data.xsd")
+    with schema_path.open(encoding="utf-8") as schema_file:
         xmlschema = etree.XMLSchema(etree.parse(schema_file))
     assert xmlschema.validate(serialised)
 

--- a/test/unittests/xmllib/models/test_root.py
+++ b/test/unittests/xmllib/models/test_root.py
@@ -1,4 +1,5 @@
 # mypy: disable-error-code="comparison-overlap"
+import importlib.resources
 import warnings
 
 import pytest
@@ -393,6 +394,32 @@ def test_make_authorship_lookup() -> None:
     region_res = RegionResource.create_new("regionID", "label", "id1")
     result = _make_authorship_lookup([res1, res2, res3, region_res, res_none])
     assert set(result.lookup.keys()) == {("auth", "auth1"), tuple(["auth2"])}
+
+
+def test_make_authorship_lookup_with_resource_authorship() -> None:
+    res_resource_auth = Resource.create_new("id1", ":Restype", "label", authorship=["resource auth"])
+    res_shared_auth = Resource.create_new("id2", ":Restype", "label", authorship=["auth2"]).add_file(
+        "file.jpg", LicenseRecommended.DSP.UNKNOWN, "copy", ["auth2"]
+    )
+    res_no_auth = Resource.create_new("id3", ":Restype", "label")
+    result = _make_authorship_lookup([res_resource_auth, res_shared_auth, res_no_auth])
+    assert set(result.lookup.keys()) == {tuple(["resource auth"]), tuple(["auth2"])}
+
+
+def test_serialise_resource_authorship_is_xsd_valid() -> None:
+    xml_root = XMLRoot.create_new("0000", "test")
+    res_with_file = Resource.create_new("id_1", ":ResType", "lbl", authorship=["auth1"]).add_file(
+        "file.jpg", LicenseRecommended.DSP.UNKNOWN, "copy", ["auth1"]
+    )
+    xml_root.add_resource(res_with_file)
+    serialised = xml_root.serialise()
+    resource_ele = next(serialised.iterdescendants(tag=f"{DASCH_SCHEMA}resource"))
+    bitstream_ele = next(serialised.iterdescendants(tag=f"{DASCH_SCHEMA}bitstream"))
+    assert resource_ele.attrib["authorship-id"] == bitstream_ele.attrib["authorship-id"]
+    schema_res = importlib.resources.files("dsp_tools").joinpath("resources/schema/data.xsd")
+    with schema_res.open(encoding="utf-8") as schema_file:
+        xmlschema = etree.XMLSchema(etree.parse(schema_file))
+    assert xmlschema.validate(serialised)
 
 
 def test_serialise_authorship() -> None:


### PR DESCRIPTION
## Summary

Adds xmllib support for resource-record authorship (`hasResourceAuthorship`), deferred from #2350.

`Resource.create_new()` accepts an `authorship` parameter, mirroring the asset authorship on `add_file()`/`add_iiif_uri()`: the user passes a plain list of names, ids stay internal.

- The authorship validation logic from `Metadata.new` is extracted into a shared `check_and_fix_authorship_input()` so files and resources behave identically.
- `_make_authorship_lookup` also collects resource-level author tuples — a resource and a file with the same authors share one id in the top-level `<authorship>` pool.
- The serialiser emits `authorship-id` on the `<resource>` element when set.
- Docs: new section in `overview.md` + `create_new` docstring.

## Notes

- **Stacked on #2350** (`feature/dev-6666-tools-resource-side-legal`) because the XSD change (`authorship-id` on `resource_type`) lives there. Retarget to `main` once #2350 merges.
- End-to-end upload of resource authorship needs dasch-swiss/dsp-api#4173 deployed; this PR only concerns XML generation.

## Tests

TDD: 8 new tests covering input validation, lookup dedup across files and resources, serialisation, and a full `XMLRoot.serialise()` round-trip validated against `data.xsd`. All unit (2606), integration (128), ruff, mypy, vulture, markdownlint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014HCy4paZicL9wJhQJYwWeb