### PR TITLE
docs: add CONVENTIONS.md and REVIEW.md reference cards (DEV-6719)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+See also `CONVENTIONS.md` (work-phase reference card — naming, schemas, test data, e2e wiring,
+architecture boundaries) and `REVIEW.md` (review-phase checklist). Update them alongside this file
+whenever a convention changes.
+
 ## What is DSP-TOOLS?
 
 DSP-TOOLS is a CLI tool for interacting with the DaSCH Service Platform (DSP) API.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,0 +1,82 @@
+# Conventions
+
+Agent reference card for the **work phase**. Pair with `REVIEW.md` (review phase).
+Detailed developer docs live in `docs/developers/`; module-specific guidance in `CLAUDE.md`
+and `src/dsp_tools/xmllib/CLAUDE.md`. This card collects the conventions that are otherwise
+only enforced in review.
+
+## Stack
+
+Python 3.12+, `uv` for environments and dependencies, `just` as command runner.
+Linting: `ruff` (format + check), `mypy` (strict), `yamllint`/`yamlfmt`, `markdownlint`,
+`darglint` (Google-style docstrings), `vulture`. Tests: `pytest` (unit / integration / e2e
+with testcontainers). Line length: 120.
+
+## Naming
+
+- **`default_*` prefix** marks a **project-wide value that can be overridden per resource**
+  (precedent: `default_permissions`, `default_data_authorship`). A field that applies directly
+  and cannot be overridden does not take the prefix. Get this right before merging — these names
+  are cross-repo API (JSON project files, XML uploads, dsp-api payload keys); the initial
+  `data_authorship` had to be renamed across four repositories after merge.
+- "Default" does **not** imply auto-application. If a `default_*` value is only a suggestion in
+  some flows (e.g. not applied during `xmlupload`), say so explicitly in the user docs of every
+  feature that touches it.
+
+## JSON schemas
+
+- **Restricted-value fields are enums, not free strings.** If only a fixed set of values is
+  allowed (e.g. a set of license IRIs), model it as an `enum` in the JSON schema so validation
+  fails client-side with an actionable message. This is a hard requirement, not a style choice.
+- **IRI-valued fields get a `pattern`** even when not enumerable
+  (precedent: `enabled_licenses` in `src/dsp_tools/resources/schema/project.json`).
+
+## Test data
+
+- **Systematic test data contains every supported feature.** New features extend the systematic
+  fixtures (`testdata/`, e.g. the systematic JSON project and XML data files) — do not add
+  standalone one-off fixtures for a new feature and leave the systematic data untouched.
+- **Test-project shortcodes come from the team's shortcode register** — do not invent one.
+  Ask the reviewers where the register lives before allocating.
+  <!-- TODO(reviewers): link the shortcode register location here. -->
+
+## Testing
+
+- Test locations: unit → `test/unittests/`, integration → `test/integration/`,
+  e2e (testcontainers) → `test/e2e/`.
+- **E2E tests are not auto-discovered by CI.** Each e2e command suite is wired explicitly:
+  a test directory under `test/e2e/commands/`, a `just e2e-test-<command>` recipe in the
+  `justfile`, and a matching job in `.github/workflows/tests-e2e.yml`. A new e2e test that is
+  not registered in all three places silently never runs.
+
+## Architecture boundaries
+
+- **xmllib is the public API** for programmatic XML creation
+  (see `src/dsp_tools/xmllib/CLAUDE.md`). It must not import dsp-tools internals and it does not
+  know the JSON project file — dependencies point from dsp-tools *into* xmllib, never the other
+  way.
+- **User-facing docs and docstrings do not cite xmllib internals** — user input is described in
+  the user's terms (XML elements, JSON fields), not in terms of library code.
+- **New RDF-mapped properties must be threaded through the validate-data pipeline**
+  (`get_rdf_like_data()` → property type → SHACL shape in
+  `src/dsp_tools/resources/validate_data/api-shapes.ttl`). The generic resource shape is
+  closed: a new property needs an explicit cardinality declaration or xmlupload fails
+  validation.
+
+## Commit conventions
+
+[Conventional Commits](https://www.conventionalcommits.org/), enforced by the
+"Check PR Title" workflow: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`;
+breaking changes use `!`.
+
+## PR reviewers
+
+Request review from the maintainers listed in `CLAUDE.md`
+(BalduinLandolt, Nora-Olivia-Ammann, Notheturtle, seakayone, jnussbaum).
+
+## Where to go for depth
+
+- `CLAUDE.md` — architecture overview, commands, testing strategy
+- `src/dsp_tools/xmllib/CLAUDE.md` — xmllib public-API layering
+- `docs/developers/` — developer documentation (mkdocs)
+- `REVIEW.md` — review-phase checklist

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -16,9 +16,9 @@ with testcontainers). Line length: 120.
 
 - **`default_*` prefix** marks a **project-wide value that can be overridden per resource**
   (precedent: `default_permissions`, `default_data_authorship`). A field that applies directly
-  and cannot be overridden does not take the prefix. Get this right before merging — these names
-  are cross-repo API (JSON project files, XML uploads, dsp-api payload keys); the initial
-  `data_authorship` had to be renamed across four repositories after merge.
+  and cannot be overridden does not take the prefix. These names are cross-repo API (JSON project
+  files, XML uploads, dsp-api payload keys) — get them right before merging; renaming afterwards
+  is a breaking change.
 - "Default" does **not** imply auto-application. If a `default_*` value is only a suggestion in
   some flows (e.g. not applied during `xmlupload`), say so explicitly in the user docs of every
   feature that touches it.
@@ -48,6 +48,10 @@ with testcontainers). Line length: 120.
   a test directory under `test/e2e/commands/`, a `just e2e-test-<command>` recipe in the
   `justfile`, and a matching job in `.github/workflows/tests-e2e.yml`. A new e2e test that is
   not registered in all three places silently never runs.
+- **A new GitHub workflow is not a required check automatically.** Adding a workflow only makes
+  it run; it does not gate merging. A repo admin must mark it as a required status check in the
+  GitHub settings (branch protection / rulesets). Agents and tools cannot change repo settings —
+  when adding a workflow, flag this step to the user explicitly.
 
 ## Architecture boundaries
 
@@ -68,11 +72,6 @@ with testcontainers). Line length: 120.
 [Conventional Commits](https://www.conventionalcommits.org/), enforced by the
 "Check PR Title" workflow: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`;
 breaking changes use `!`.
-
-## PR reviewers
-
-Request review from the maintainers listed in `CLAUDE.md`
-(BalduinLandolt, Nora-Olivia-Ammann, Notheturtle, seakayone, jnussbaum).
 
 ## Where to go for depth
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,56 @@
+# Code Review Checklist
+
+Agent reference card for the **review phase**. Pair with `CONVENTIONS.md` (work phase).
+
+## Always check
+
+### Build & history
+
+- [ ] `just lint` passes (ruff format + check, mypy, yamllint, markdownlint, darglint, vulture)
+- [ ] Unit / integration / e2e tests cover the changed behaviour
+- [ ] Commits and PR title follow Conventional Commits (`feat:` / `fix:` / `docs:` / …)
+
+### Naming
+
+- [ ] Project-wide overridable values are named with the `default_*` prefix; directly applied
+      values are not — renaming after merge is a cross-repo breaking change
+- [ ] If a `default_*` value is not auto-applied in some flow (e.g. `xmlupload`), the user docs
+      of that flow say so explicitly
+
+### JSON schemas
+
+- [ ] Fields with a fixed set of allowed values are schema `enum`s, not free strings with a
+      documented constraint
+- [ ] IRI-valued fields have a `pattern` (precedent: `enabled_licenses` in `project.json`)
+
+### Test data
+
+- [ ] New features are exercised in the **systematic** test data, not only in standalone
+      ad-hoc fixtures
+- [ ] New test-project shortcodes come from the team's shortcode register, not invented
+
+### E2E wiring
+
+- [ ] A new e2e command suite is registered in all three places: `test/e2e/commands/<command>/`,
+      a `just e2e-test-<command>` recipe, and a job in `.github/workflows/tests-e2e.yml`
+      — otherwise it silently never runs in CI
+
+### Architecture boundaries
+
+- [ ] xmllib does not import dsp-tools internals and has no knowledge of the JSON project file
+- [ ] User-facing docs and docstrings describe user input (XML elements, JSON fields), not
+      xmllib internals
+- [ ] New RDF-mapped properties are threaded through the validate-data pipeline and have an
+      explicit cardinality in `api-shapes.ttl` (the generic resource shape is closed)
+
+### Docs
+
+- [ ] User documentation (mkdocs) updated where behaviour changed; statements about the same
+      feature do not contradict each other across pages
+- [ ] `CLAUDE.md` / `CONVENTIONS.md` / `REVIEW.md` updated if a convention changed
+
+## Skip
+
+- Formatting-only diffs (enforced by `ruff format` / `yamlfmt`)
+- `CHANGELOG.md` and release commits (managed by release automation)
+- Generated or vendored sources

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -34,6 +34,8 @@ Agent reference card for the **review phase**. Pair with `CONVENTIONS.md` (work 
 - [ ] A new e2e command suite is registered in all three places: `test/e2e/commands/<command>/`,
       a `just e2e-test-<command>` recipe, and a job in `.github/workflows/tests-e2e.yml`
       — otherwise it silently never runs in CI
+- [ ] A new GitHub workflow that should gate merging has been marked as a required status check
+      in the repo settings (manual admin step — flag it in the PR if not yet done)
 
 ### Architecture boundaries
 


### PR DESCRIPTION
Part of DEV-6719 — https://linear.app/dasch/issue/DEV-6719

## Motivation

The #2350 review took 20 threads over six rounds — and most of them were one reviewer teaching conventions that exist only in reviewers' heads: the shortcode register, the systematic-test-data rule, "restricted values are schema enums" as a hard requirement, the `default_*` naming prefix, the xmllib boundary, and the fact that e2e tests must be wired into the justfile and CI by hand. dsp-api already keeps exactly this knowledge in root `CONVENTIONS.md`/`REVIEW.md` reference cards (its legal-metadata PRs got zero review threads). This PR ports that pattern.

## Summary

Two new root reference cards, written from the actual review feedback on #2350, plus a pointer in `CLAUDE.md`. Root files are not in the mkdocs nav — no nav changes.

## Key Changes

- **`CONVENTIONS.md`** (new) — work-phase card: `default_*` naming (and "default ≠ auto-apply" documentation duty), JSON-schema enum/pattern rules, systematic test data + shortcode register, e2e three-place registration (test dir + justfile recipe + CI job), xmllib boundary and validate-data/SHACL threading, commit conventions, reviewer list, depth pointers.
- **`REVIEW.md`** (new) — matching review-phase checklist.
- **`CLAUDE.md`** — pointer to both files.

## Challenges and Decisions

- The shortcode register is referenced in review feedback but not discoverable in the repo — the card says to ask before allocating, with a **TODO for reviewers to link the register's location** (see question below).
- Content is deliberately limited to rules that reviewers actually enforced on #2350 (plus the cross-repo `default_*` rule); no speculative conventions.

## Gotchas

- @Nora-Olivia-Ammann: where does the shortcode register live? I'd like to replace the TODO in `CONVENTIONS.md` § Test data with a real pointer.
- @BalduinLandolt: you mentioned adding CONVENTIONS/REVIEW during the #2350 review — this is a draft starting point in your dsp-api format; reshape freely.

## Test Plan

- `markdownlint` clean on all three files (repo config, 120-char lines).
- Facts verified against main: `test/{unittests,integration,e2e}` layout, justfile e2e recipes, per-command jobs in `.github/workflows/tests-e2e.yml`, `enabled_licenses` pattern in `project.json`, `src/dsp_tools/xmllib/CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
