### PR TITLE
fix(create): exit with code 3 from --exit-if-exists when the project already exists (DEV-6878)

### DIFF
--- a/docs/data-model/data-model-cli.md
+++ b/docs/data-model/data-model-cli.md
@@ -19,6 +19,22 @@ The most frequently used options are:
 
 To see all possible options, type `dsp-tools create --help`.
 
+### The `--exit-if-exists` flag
+
+By default, if a project with the same shortcode already exists on the server,
+`create` continues and adds the definitions from the JSON file to the existing project.
+Pass `--exit-if-exists` to abort instead, as soon as an existing project is detected,
+without uploading anything.
+
+This is useful in automated pipelines that must not modify an already-existing project.
+Depending on the outcome, the command exits with one of these codes:
+
+- `0`: the project did not exist yet and was created.
+- `3`: the project already existed, so nothing was uploaded.
+- `1`: the command failed for another reason.
+
+A calling script can check for exit code `3` to skip subsequent steps (such as a data upload) gracefully.
+
 The defaults are intended for local testing:
 
 ```bash

--- a/docs/developers/architecture/error-handling.md
+++ b/docs/developers/architecture/error-handling.md
@@ -103,6 +103,22 @@ BaseError                               # Root. Dataclass with message: str attr
 - `UserError` and `InternalError` are the **only** allowed direct subclasses of `BaseError`.
   All new exception classes must inherit from one of them, never from `BaseError` itself.
 
+## Exit codes
+
+The process exit code communicates the outcome to shells and CI jobs. The convention is:
+
+| Code  | Meaning                                                                                                                                                   |
+| ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `0`   | Success.                                                                                                                                                   |
+| `1`   | General failure: a command returned `False`, or a `UserError` / `InternalError` (or any other exception) escaped to the top-level handler in `entry_point.py`. |
+| `2`   | Invalid command-line arguments (emitted by `argparse`).                                                                                                    |
+| `3`   | `create --exit-if-exists`: the project already exists on the server, so the command aborted without further uploads. Lets a caller distinguish "already exists" from both success and failure and skip subsequent steps gracefully. |
+| `130` | Interrupted by the user (`KeyboardInterrupt`, i.e. Ctrl-C).                                                                                                 |
+
+Codes other than `0` and `1` are used sparingly — only where a caller needs to react differently to a
+specific, machine-readable outcome. Most failures should surface as `1` via the `entry_point.py` handler;
+introduce a dedicated code only when it is genuinely required.
+
 ## When to Catch vs. Let Fail
 
 ### Do NOT catch

--- a/src/dsp_tools/cli/create_parsers.py
+++ b/src/dsp_tools/cli/create_parsers.py
@@ -445,7 +445,7 @@ def _add_create(
     subparser.add_argument(
         "--exit-if-exists",
         action="store_true",
-        help="exit gracefully without further uploads if the project already exists",
+        help="if the project already exists, abort without further uploads (exit code 3)",
     )
     subparser.add_argument(
         "-V",

--- a/src/dsp_tools/commands/create/CLAUDE.md
+++ b/src/dsp_tools/commands/create/CLAUDE.md
@@ -167,7 +167,8 @@ All creation follows strict sequential order because of dependencies.
 
 - Creates project metadata on server
 - Returns project IRI for subsequent operations
-- Handles `exit_if_exists` flag
+- Handles the `exit_if_exists` flag: if the project already exists, aborts and exits with a dedicated
+  exit code (`EXIT_CODE_PROJECT_ALREADY_EXISTS`, currently `3`) so callers can distinguish this outcome
 
 **2. Lists** (`lists.py: create_lists()`)
 

--- a/src/dsp_tools/commands/create/create_on_server/project.py
+++ b/src/dsp_tools/commands/create/create_on_server/project.py
@@ -19,6 +19,8 @@ from dsp_tools.setup.ansi_colors import RESET_TO_DEFAULT
 from dsp_tools.utils.interactive import prompt_until_valid_answer
 from dsp_tools.utils.request_utils import is_server_error
 
+EXIT_CODE_PROJECT_ALREADY_EXISTS = 3
+
 
 def create_project(project: ParsedProjectMetadata, auth: AuthenticationClient, exit_if_exists: bool) -> str:
     client = ProjectClientLive(auth.server, auth)
@@ -49,11 +51,11 @@ def _exit_if_create_should_not_continue(shortcode: str, exit_if_exists: bool) ->
     if exit_if_exists:
         msg = (
             "The project already exists on the server and the flag '--exit-if-exists' was set. "
-            "The process is aborted without further uploads."
+            f"The process is aborted without further uploads (exit code {EXIT_CODE_PROJECT_ALREADY_EXISTS})."
         )
         logger.info(msg)
         print(BACKGROUND_BOLD_YELLOW + msg + RESET_TO_DEFAULT)
-        sys.exit(0)
+        sys.exit(EXIT_CODE_PROJECT_ALREADY_EXISTS)
 
     msg = (
         f"A project with the shortcode '{shortcode}' already exists on the server. "

--- a/test/unittests/commands/create/create_on_server/test_project.py
+++ b/test/unittests/commands/create/create_on_server/test_project.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from dsp_tools.clients.exceptions import ProjectNotFoundError
+from dsp_tools.commands.create.create_on_server.project import EXIT_CODE_PROJECT_ALREADY_EXISTS
 from dsp_tools.commands.create.create_on_server.project import create_project
 from dsp_tools.commands.create.exceptions import UnableToCreateProjectError
 from dsp_tools.commands.create.models.parsed_project import ParsedProjectMetadata
@@ -87,14 +88,14 @@ def test_project_exit_through_flag(
     mock_client = Mock()
     mock_client.get_project_iri.return_value = PROJECT_IRI
     mock_client_class.return_value = mock_client
-    mock_exit.side_effect = SystemExit(0)
+    mock_exit.side_effect = SystemExit(EXIT_CODE_PROJECT_ALREADY_EXISTS)
 
     with pytest.raises(SystemExit):
         create_project(parsed_project, mock_auth, True)
 
     mock_client_class.assert_called_once_with(mock_auth.server, mock_auth)
     mock_client.get_project_iri.assert_called_once_with(parsed_project.shortcode)
-    mock_exit.assert_called_once_with(0)
+    mock_exit.assert_called_once_with(EXIT_CODE_PROJECT_ALREADY_EXISTS)
 
 
 @patch("dsp_tools.commands.create.create_on_server.project.ProjectClientLive")


### PR DESCRIPTION
## What

`dsp-tools create --exit-if-exists` now exits with a dedicated exit code **`3`** when the project
already exists on the server, instead of `sys.exit(0)`.

## Why

Previously, when the project already existed, `--exit-if-exists` called `sys.exit(0)` — indistinguishable
from a normal successful create. A consuming CI job (the daschland-scripts `create-on-stage` workflow)
could therefore not tell "already exists" apart from "created successfully", so it proceeded to the
subsequent `xmlupload` step and **created duplicate resources** in the Alice showcase project.

With a distinct exit code, a caller can tell the three outcomes apart and skip subsequent steps gracefully:

| Code | Meaning |
| ---- | ------- |
| `0`  | project did not exist yet and was created |
| `3`  | project already existed → aborted without further uploads |
| `1`  | any other failure |

## Changes

- `create_on_server/project.py`: new module constant `EXIT_CODE_PROJECT_ALREADY_EXISTS = 3`; the
  `--exit-if-exists` branch now exits with `3` (and the printed message states the code).
- `create_parsers.py`: updated the `--exit-if-exists` help text.
- Docs: added an `--exit-if-exists` section to the user-facing CLI docs, and an exit-code reference table
  to the developer error-handling guideline.
- Updated the unit test `test_project_exit_through_flag` to assert exit code `3`.

## Reviewer notes

- The interactive "project exists → user answers `n`" abort is intentionally left at exit `1` — it is a
  human-initiated abort, distinct from the `--exit-if-exists` case, and out of scope here.
- `SystemExit(3)` propagates cleanly: `entry_point.run()` catches `KeyboardInterrupt` / `UserError` /
  `Exception`, none of which match `SystemExit`, so the process exits with `3`.
- **Consumer:** the daschland-scripts `create-on-stage.yml` / `create-on-dev.yml` workflows are updated in
  a separate PR to read exit code `3` and skip `xmlupload`. Those workflows run `uv add --upgrade
  dsp-tools` at runtime, so the new behavior takes effect once this change is released to PyPI; the
  consumer change is forward-compatible and cannot break before then.

## Verification

`pytest` on the affected unit tests (create/project + CLI wiring), `ruff`, `mypy`, and `markdownlint` all pass.
