### PR TITLE
docs: clarify Region / region-preview / link docs and terminology (stacked on #2369)

### DIFF
--- a/docs/data-file/xml-data-file.md
+++ b/docs/data-file/xml-data-file.md
@@ -844,8 +844,13 @@ and a link to `<resource id="res_2" ...>`:
 
 ### `<region-preview-prop>`
 
-The `<region-preview-prop>` element links a Region so that it can be rendered as a preview.
+The `<region-preview-prop>` element links a Region (see [`<region>`](#region)) so that the region's
+image area is rendered as a standalone preview (a cropped image) on this resource.
 It must contain at least one `<region-preview>` element.
+
+Region previews only work with still images: the preview is a crop of the source image, so the linked
+Region should be a region of a `StillImageRepresentation`.
+In DSP-APP, a Region is called an **"Annotation"**, so this feature appears there as an _annotation preview_.
 
 The property must be defined in the ontology with `super: hasRegionPreview`, `object: RegionPreviewValue`, and
 `gui_element: RegionPreview`
@@ -860,6 +865,8 @@ Attributes:
 
 The `<region-preview>` element contains either the internal ID of a Region inside the XML or the IRI of an already
 existing Region on DSP. The target must be a Region; this is checked by `validate-data` before the upload.
+As with any Region (in DSP-APP: **"Annotation"**), a preview only makes sense when that Region belongs to a
+still image.
 
 Attributes:
 

--- a/docs/data-file/xml-data-file.md
+++ b/docs/data-file/xml-data-file.md
@@ -1248,6 +1248,19 @@ A `<region>` resource defines a region of interest (ROI) in an image. It must ha
 - `hasGeometry` (1)
 - `hasComment` (0-n)
 
+`isRegionOf` links the region to the resource it belongs to.
+Regions delimit a 2-D area with pixel coordinates, so they are only meaningful on a still image:
+DSP-APP renders regions on `StillImageRepresentation` resources only.
+`validate-data` accepts any `Representation` as the target (mirroring the DSP-API's `isRegionOf`
+constraint), but region rendering only works for still images.
+
+!!! note "Region vs. Annotation"
+
+    In DSP-APP, a `<region>` is displayed under the label **"Annotation"** of an image,
+    even though it is in fact a region of interest.
+    "Region" (the term used by the DSP-API backend and dsp-tools, i.e. `knora-base:Region`)
+    and "Annotation" (the term used in the DSP-APP user interface) denote the same entity.
+
 Example:
 
 ```xml

--- a/docs/data-model/json-project/caveats.md
+++ b/docs/data-model/json-project/caveats.md
@@ -47,7 +47,7 @@ However, they can be used directly in the XML data file:
     - `hasColor` (1)
     - `isRegionOf` (1)
     - `hasGeometry` (1)
-    - `hasComment` (1-n)
+    - `hasComment` (0-n)
 
 There are some DSP base properties that are used directly in the above-mentioned resource classes. 
 Subclasses can be created from some of them in the project ontology.

--- a/docs/data-model/json-project/caveats.md
+++ b/docs/data-model/json-project/caveats.md
@@ -41,7 +41,7 @@ However, they can be used directly in the XML data file:
   has the following predefined properties:
     - `hasComment` (0-n)
     - `hasLinkTo` (1-n)
-- A `Region` resource defines a region of interest (ROI) in an image. 
+- A `Region` resource defines a region of interest (ROI) in an image (displayed as an *Annotation* in DSP-APP). 
   It can be used in the XML file with the [&lt;region&gt; tag](../../data-file/xml-data-file.md#region) and 
   has the following predefined properties:
     - `hasColor` (1)

--- a/docs/data-model/json-project/ontologies.md
+++ b/docs/data-model/json-project/ontologies.md
@@ -623,7 +623,7 @@ from `hasLinkTo`. There are different groups of resource classes that can be the
 - DSP base resources:
     - `Resource`: the most generic one, can point to any resource class, be it a DSP base resource, a project resource, 
       or an external resource. `Resource` is at the very top of the inheritance hierarchy.
-    - `Region`: a region in an image
+    - `Region`: a region in an image (displayed as an *Annotation* in DSP-APP)
     - `StillImageRepresentation`, `MovingImageRepresentation`, `TextRepresentation`, `AudioRepresentation`, 
       `DDDRepresentation`, `DocumentRepresentation`, or `ArchiveRepresentation`
 

--- a/src/dsp_tools/xmllib/models/dsp_base_resources.py
+++ b/src/dsp_tools/xmllib/models/dsp_base_resources.py
@@ -49,6 +49,7 @@ class RegionResource:
         """
         Creates a new region resource.
         A region is a region of interest (ROI) in a StillImageRepresentation.
+        In DSP-APP, a region is displayed under the label "Annotation".
 
         Exactly one geometry shape has to be added to the resource with one of the following methods:
         `add_rectangle`, `add_polygon`, `add_circle` (see documentation below for more information).

--- a/src/dsp_tools/xmllib/models/res.py
+++ b/src/dsp_tools/xmllib/models/res.py
@@ -910,13 +910,14 @@ class Resource:
         order: int | None = None,
     ) -> Resource:
         """
-        Add a link value to the resource, in the form of an ID of another resource.
+        Add a link value to the resource. The value is either the internal ID of another resource
+        inside the XML, or the IRI of an already existing resource on DSP.
 
         [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#resptr)
 
         Args:
             prop_name: name of the property
-            value: target resource ID
+            value: internal ID of another resource inside the XML, or IRI of an already existing resource on DSP
             permissions: optional permissions of this value
             comment: optional comment
             order: Position at which this value is displayed in the app (starting at 0),
@@ -955,13 +956,15 @@ class Resource:
         include_value_order: bool = False,
     ) -> Resource:
         """
-        Add several link values to the resource, in the form of IDs of other resources.
+        Add several link values to the resource. Each value is either the internal ID of another
+        resource inside the XML, or the IRI of an already existing resource on DSP.
 
         [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#resptr)
 
         Args:
             prop_name: name of the property
-            values: list of target resources IDs
+            values: list of targets, each the internal ID of another resource inside the XML,
+                or the IRI of an already existing resource on DSP
             permissions: optional permissions of this value
             comment: optional comment
             include_value_order: If True, each value is assigned a persistent display order
@@ -998,13 +1001,15 @@ class Resource:
     ) -> Resource:
         """
         If the value is not empty, add it to the resource, otherwise return the resource unchanged.
-        If non-empty, the value must be an ID of another resource.
+        If non-empty, the value must be the internal ID of another resource inside the XML,
+        or the IRI of an already existing resource on DSP.
 
         [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#resptr)
 
         Args:
             prop_name: name of the property
-            value: target resource ID or empty value
+            value: internal ID of another resource inside the XML,
+                or IRI of an already existing resource on DSP, or empty value
             permissions: optional permissions of this value
             comment: optional comment
 

--- a/src/dsp_tools/xmllib/models/res.py
+++ b/src/dsp_tools/xmllib/models/res.py
@@ -1043,13 +1043,14 @@ class Resource:
         order: int | None = None,
     ) -> Resource:
         """
-        Add a region-preview value to the resource, in the form of an ID of a Region resource.
+        Add a region-preview value to the resource. The value is either the internal ID of a Region
+        inside the XML, or the IRI of an already existing Region on DSP.
 
         [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#region-preview)
 
         Args:
             prop_name: name of the property
-            value: ID of the target Region resource
+            value: internal ID of a Region inside the XML, or IRI of an already existing Region on DSP
             permissions: optional permissions of this value
             comment: optional comment
             order: Position at which this value is displayed in the app (starting at 0),
@@ -1088,13 +1089,15 @@ class Resource:
         include_value_order: bool = False,
     ) -> Resource:
         """
-        Add several region-preview values to the resource, in the form of IDs of Region resources.
+        Add several region-preview values to the resource. Each value is either the internal ID of a
+        Region inside the XML, or the IRI of an already existing Region on DSP.
 
         [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#region-preview)
 
         Args:
             prop_name: name of the property
-            values: list of target Region resource IDs
+            values: list of targets, each the internal ID of a Region inside the XML,
+                or the IRI of an already existing Region on DSP
             permissions: optional permissions of this value
             comment: optional comment
             include_value_order: If True, each value is assigned a persistent display order
@@ -1131,13 +1134,14 @@ class Resource:
     ) -> Resource:
         """
         If the value is not empty, add it to the resource, otherwise return the resource unchanged.
-        If non-empty, the value must be an ID of a Region resource.
+        If non-empty, the value must be the internal ID of a Region inside the XML,
+        or the IRI of an already existing Region on DSP.
 
         [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#region-preview)
 
         Args:
             prop_name: name of the property
-            value: target Region resource ID or empty value
+            value: internal ID of a Region inside the XML, or IRI of an existing Region on DSP, or empty value
             permissions: optional permissions of this value
             comment: optional comment
 

--- a/test/integration/commands/create/test_create_project.py
+++ b/test/integration/commands/create/test_create_project.py
@@ -45,8 +45,8 @@ def test_json_schema_validation_error():
 
 
 def test_json_schema_validation_accepts_region_preview() -> None:
-    # regression: `create` validates against project.json (not properties-only.json); a project property with
-    # super hasRegionPreview / object Region / gui_element RegionPreview must pass the create-pipeline schema.
+    # A project property using the region-preview GUI element (super hasRegionPreview, object Region,
+    # gui_element RegionPreview) must be accepted by the create pipeline's JSON-schema validation.
     with open("testdata/validate-data/core_validation/core-validation-project-9999.json", encoding="utf-8") as f:
         project = json.load(f)
     _validate_with_json_schema(project)


### PR DESCRIPTION
Docs, docstrings, and one test comment only — no runtime behaviour changes. Base branch: `feature/dev-6760-region-preview-links-dsp-tools` (stacked on #2369).

## `<region>` — `docs/data-file/xml-data-file.md`

- `isRegionOf` is documented as targeting a `Representation` (mirroring the DSP-API's `isRegionOf` ontology constraint); in practice a `StillImageRepresentation`, since regions only render on still images in DSP-APP.
- A **"Region vs. Annotation"** note: DSP-APP labels a `<region>` an *Annotation*; `knora-base:Region` (backend / dsp-tools) and *Annotation* (app UI) are the same entity.

## `<region-preview>` — `docs/data-file/xml-data-file.md`

- The `<region-preview-prop>` / `<region-preview>` sections state that region previews only work with still images (the preview is a crop of the source image), and that the referenced Region is an *Annotation* in DSP-APP.

## Region = Annotation terminology

- `docs/data-model/json-project/caveats.md` and `docs/data-model/json-project/ontologies.md`: the `Region` base resource is noted as displayed as an *Annotation* in DSP-APP.
- `src/dsp_tools/xmllib/models/dsp_base_resources.py`: one-line Annotation aside in the `RegionResource` docstring.

## xmllib docstrings: value may be an ID *or* an IRI — `src/dsp_tools/xmllib/models/res.py`

- `add_region_preview` / `_multiple` / `_optional` and `add_link` / `_multiple` / `_optional` document their value as the internal ID of the target inside the XML, **or** the IRI of an already existing target on DSP — matching the `<region-preview>` / `<resptr>` XML docs and the `is_link_value` validator (`expected_type="xsd:ID or DSP resource IRI"`).

## `Region` cardinality — `docs/data-model/json-project/caveats.md`

- The `Region` predefined-property list shows `hasComment (0-n)` (was `(1-n)`), matching `xml-data-file.md`, `data.xsd` (`minOccurs="0"`), and knora-base.

## Test comment — `test/integration/commands/create/test_create_project.py`

- The `test_json_schema_validation_accepts_region_preview` comment states the current requirement (a region-preview project property must pass the create pipeline's `project.json` schema validation), as an evergreen comment. Test body and assertion unchanged.

## Verification

- `just markdownlint`, `just ruff-check`, and `just ruff-format-check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
