### PR TITLE
docs: fix Region hasComment cardinality in caveats.md

### DIFF
--- a/docs/data-model/json-project/caveats.md
+++ b/docs/data-model/json-project/caveats.md
@@ -47,7 +47,7 @@ However, they can be used directly in the XML data file:
     - `hasColor` (1)
     - `isRegionOf` (1)
     - `hasGeometry` (1)
-    - `hasComment` (1-n)
+    - `hasComment` (0-n)
 
 There are some DSP base properties that are used directly in the above-mentioned resource classes. 
 Subclasses can be created from some of them in the project ontology.


### PR DESCRIPTION
## What

Fixes an incorrect cardinality in the JSON-project caveats docs. On the `Region` DSP base resource, the predefined property `hasComment` was documented as `(1-n)` (required, one or more). It is actually **optional** — `(0-n)`.

`docs/data-model/json-project/caveats.md` (~line 50):

```diff
-    - `hasComment` (1-n)
+    - `hasComment` (0-n)
```

## Why

`hasComment` on a `Region` is optional, and every other source of truth already agrees:

- `docs/data-file/xml-data-file.md` — the `<region>` section lists `hasComment (0-n)`.
- `src/dsp_tools/resources/schema/data.xsd` — `region_type` defines the `text-prop` (hasComment) with `minOccurs="0"`.
- knora-base — the `:Region` restriction on `:hasComment` uses `owl:minCardinality 0`.

This entry in `caveats.md` was the only place still claiming the property was required.

## Notes for the reviewer

- Deliberately **isolated, independent** one-line docs fix against `main` — **not** stacked on the region-preview feature branch (`feature/dev-6760-region-preview-links-dsp-tools`).
- The broader region-clarification + "Annotation" terminology work lives in a separate PR (stacked on #2369) and was intentionally kept out of this PR to let the cardinality fix land on its own.
- `just markdownlint` passes with no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
