### PR TITLE
chore(ci): auto-merge the dsp-tools release-train PRs via the DaSCH Bot App (DEV-6956)

### DIFF
--- a/.github/actions/merge-pr-when-green/action.yml
+++ b/.github/actions/merge-pr-when-green/action.yml
@@ -1,0 +1,60 @@
+---
+
+name: Merge PR when green
+description: >
+  Merge a bot-authored PR into main as soon as its required status checks pass,
+  using the DaSCH Bot App as review-bypass actor. Used by the release-train
+  follow-on PRs (start-stack bump, release-please release).
+inputs:
+  pr-url:
+    description: URL of the pull request to merge
+    required: true
+  token:
+    description: DaSCH Bot App installation token with contents+pull-requests write on this repo
+    required: true
+  timeout-minutes:
+    description: How long to wait for the required checks to go green before failing
+    required: false
+    default: "30"
+runs:
+  using: "composite"
+  steps:
+    # `main` requires 13 status checks + 1 review, is strict (branch must be up
+    # to date), and has enforce_admins on. GitHub's native auto-merge is
+    # unusable here: it ignores bypass allowances and waits for a real approval
+    # that never comes for a bot-authored PR. The App is a bypass actor for the
+    # *review* only — required status checks have no per-actor bypass under
+    # branch protection. So a direct `--admin` merge is rejected by the server
+    # until every required check passes, then the review bypass lets it through.
+    # Retrying the merge therefore both waits for the checks AND can never merge
+    # before they are green. (`--admin` only skips gh's client-side mergeability
+    # refusal; the server still enforces the checks.)
+    - name: Merge once required checks pass
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        PR_URL: ${{ inputs.pr-url }}
+        TIMEOUT_MINUTES: ${{ inputs.timeout-minutes }}
+      run: |
+        set -euo pipefail
+        echo "::notice::merging $PR_URL once required checks pass (App bypasses the review)"
+        deadline=$(( $(date +%s) + TIMEOUT_MINUTES * 60 ))
+        until merge_out=$(gh pr merge --squash --admin "$PR_URL" 2>&1); do
+          echo "$merge_out"
+          if [[ "$(gh pr view "$PR_URL" --json state --jq .state 2>/dev/null)" == "MERGED" ]]; then
+            break
+          fi
+          if (( $(date +%s) >= deadline )); then
+            echo "::error::could not merge $PR_URL within budget (check failing or branch blocked)"
+            exit 1
+          fi
+          # main is strict, so a branch behind base can never merge. Refresh only
+          # when the merge output says so; doing it unconditionally would
+          # re-trigger the checks every loop and never converge.
+          if grep -qiE "not up to date|out of date|base branch was modified|behind" <<<"$merge_out"; then
+            echo "::notice::branch behind base; updating"
+            gh pr update-branch "$PR_URL" >/dev/null 2>&1 || true
+          fi
+          sleep 30
+        done
+        echo "::notice::merged $PR_URL"

--- a/.github/workflows/bump-stack-versions.yml
+++ b/.github/workflows/bump-stack-versions.yml
@@ -26,6 +26,12 @@ permissions:
   contents: write
   pull-requests: write
 
+# Per-release group lets unrelated releases run in parallel; same-release
+# dispatches serialise, so two runs can't race on the same bump PR.
+concurrency:
+  group: bump-stack-versions-${{ inputs.release }}
+  cancel-in-progress: false
+
 jobs:
   bump:
     runs-on: ubuntu-latest
@@ -53,3 +59,64 @@ jobs:
           API: ${{ inputs.api }}
           APP: ${{ inputs.app }}
           DB: ${{ inputs.db }}
+
+      - name: Find the bump PR to merge (kill switch, idempotency guard)
+        id: find_pr
+        env:
+          GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
+          RELEASE: ${{ inputs.release }}
+          # Normalize case so `False` / `FALSE` typed in the GitHub UI don't silently no-op.
+          AUTO_MERGE_ENABLED: ${{ vars.RELEASE_AUTO_MERGE_ENABLED }}
+        run: |
+          set -euo pipefail
+          if [[ "${AUTO_MERGE_ENABLED,,}" == "false" ]]; then
+            echo "::notice::RELEASE_AUTO_MERGE_ENABLED=false, leaving the bump PR for a human to merge"
+            exit 0
+          fi
+          # Branch name is the one scripts/bump_stack_versions.py creates. No open
+          # PR means either versions.env was already current (script exited early)
+          # or a previous run already merged it — both are no-ops, not errors.
+          branch="chore/bump-version-$RELEASE"
+          pr_url=$(gh pr list --head "$branch" --state open --json url --jq '.[0].url // empty')
+          if [[ -z "$pr_url" ]]; then
+            echo "::notice::no open PR on $branch, nothing to merge"
+            exit 0
+          fi
+          echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
+
+      # contents+pull-requests WRITE on dsp-tools ONLY. The App is a review-bypass
+      # actor on main, which is what lets a bot-authored PR merge without a human
+      # approval. SHA-pinned (v3 == bcd2ba4) since this action handles private-key material.
+      - name: Mint DaSCH Bot App token (write — dsp-tools only)
+        id: app-token
+        if: steps.find_pr.outputs.pr_url != ''
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
+        with:
+          app-id: ${{ secrets.DASCH_BOT_APP_ID }}
+          private-key: ${{ secrets.DASCH_BOT_APP_PRIVATE_KEY }}
+          owner: dasch-swiss
+          repositories: dsp-tools
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Merge the bump PR once its checks are green
+        if: steps.find_pr.outputs.pr_url != ''
+        uses: ./.github/actions/merge-pr-when-green
+        with:
+          pr-url: ${{ steps.find_pr.outputs.pr_url }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Notify on failure (internal)
+        if: failure()
+        env:
+          INTERNAL_WEBHOOK: ${{ secrets.GOOGLE_CHAT_DSP_RELEASE_INTERNAL_WEBHOOK_URL }}
+          RELEASE: ${{ inputs.release }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          run_url="https://github.com/$REPO/actions/runs/$RUN_ID"
+          text="❌ bump-stack-versions.yml failed for DSP=$RELEASE · <$run_url|view run>"
+          curl -fsSL -X POST -H 'Content-Type: application/json' \
+            -d "$(jq -n --arg text "$text" '{text:$text}')" \
+            "$INTERNAL_WEBHOOK"

--- a/.github/workflows/bump-stack-versions.yml
+++ b/.github/workflows/bump-stack-versions.yml
@@ -47,12 +47,13 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Bump versions
+        id: bump
         run: python scripts/bump_stack_versions.py
         env:
           # Do not use the default token (GITHUB_TOKEN) for this action,
           # as any actions triggered by the user of this token will not trigger further actions
           # (i.e. tests on the version bumping PR).
-          # See https://github.com/googleapis/release-please-action and 
+          # See https://github.com/googleapis/release-please-action and
           # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
           RELEASE: ${{ inputs.release }}
@@ -60,36 +61,26 @@ jobs:
           APP: ${{ inputs.app }}
           DB: ${{ inputs.db }}
 
-      - name: Find the bump PR to merge (kill switch, idempotency guard)
-        id: find_pr
+      - name: Check the auto-merge kill switch
+        id: kill_switch
         env:
-          GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
-          RELEASE: ${{ inputs.release }}
           # Normalize case so `False` / `FALSE` typed in the GitHub UI don't silently no-op.
           AUTO_MERGE_ENABLED: ${{ vars.RELEASE_AUTO_MERGE_ENABLED }}
         run: |
           set -euo pipefail
           if [[ "${AUTO_MERGE_ENABLED,,}" == "false" ]]; then
             echo "::notice::RELEASE_AUTO_MERGE_ENABLED=false, leaving the bump PR for a human to merge"
-            exit 0
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
           fi
-          # Branch name is the one scripts/bump_stack_versions.py creates. No open
-          # PR means either versions.env was already current (script exited early)
-          # or a previous run already merged it — both are no-ops, not errors.
-          branch="chore/bump-version-$RELEASE"
-          pr_url=$(gh pr list --head "$branch" --state open --json url --jq '.[0].url // empty')
-          if [[ -z "$pr_url" ]]; then
-            echo "::notice::no open PR on $branch, nothing to merge"
-            exit 0
-          fi
-          echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
 
       # contents+pull-requests WRITE on dsp-tools ONLY. The App is a review-bypass
       # actor on main, which is what lets a bot-authored PR merge without a human
       # approval. SHA-pinned (v3 == bcd2ba4) since this action handles private-key material.
       - name: Mint DaSCH Bot App token (write — dsp-tools only)
         id: app-token
-        if: steps.find_pr.outputs.pr_url != ''
+        if: steps.bump.outputs.pr_url != '' && steps.kill_switch.outputs.enabled == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
         with:
           app-id: ${{ secrets.DASCH_BOT_APP_ID }}
@@ -99,11 +90,13 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
+      # The script emits pr_url only when it actually opened a PR. No output means
+      # versions.env was already current — a no-op, not an error.
       - name: Merge the bump PR once its checks are green
-        if: steps.find_pr.outputs.pr_url != ''
+        if: steps.bump.outputs.pr_url != '' && steps.kill_switch.outputs.enabled == 'true'
         uses: ./.github/actions/merge-pr-when-green
         with:
-          pr-url: ${{ steps.find_pr.outputs.pr_url }}
+          pr-url: ${{ steps.bump.outputs.pr_url }}
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Notify on failure (internal)

--- a/.github/workflows/bump-stack-versions.yml
+++ b/.github/workflows/bump-stack-versions.yml
@@ -46,16 +46,31 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      # contents+pull-requests WRITE on dsp-tools ONLY. Used both to open the PR
+      # and to merge it: the App is a review-bypass actor on main, which is what
+      # lets a bot-authored PR merge without a human approval.
+      # SHA-pinned (v3 == bcd2ba4) since this action handles private-key material.
+      - name: Mint DaSCH Bot App token (write — dsp-tools only)
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
+        with:
+          app-id: ${{ secrets.DASCH_BOT_APP_ID }}
+          private-key: ${{ secrets.DASCH_BOT_APP_PRIVATE_KEY }}
+          owner: dasch-swiss
+          repositories: dsp-tools
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Bump versions
         id: bump
         run: python scripts/bump_stack_versions.py
         env:
-          # Do not use the default token (GITHUB_TOKEN) for this action,
+          # Do not use the default token (GITHUB_TOKEN) to open the PR,
           # as any actions triggered by the user of this token will not trigger further actions
-          # (i.e. tests on the version bumping PR).
-          # See https://github.com/googleapis/release-please-action and
-          # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow
-          GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
+          # (i.e. tests on the version bumping PR). An App installation token does trigger them.
+          # See https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/
+          # triggering-a-workflow#triggering-a-workflow-from-a-workflow
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           RELEASE: ${{ inputs.release }}
           API: ${{ inputs.api }}
           APP: ${{ inputs.app }}
@@ -74,21 +89,6 @@ jobs:
           else
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           fi
-
-      # contents+pull-requests WRITE on dsp-tools ONLY. The App is a review-bypass
-      # actor on main, which is what lets a bot-authored PR merge without a human
-      # approval. SHA-pinned (v3 == bcd2ba4) since this action handles private-key material.
-      - name: Mint DaSCH Bot App token (write — dsp-tools only)
-        id: app-token
-        if: steps.bump.outputs.pr_url != '' && steps.kill_switch.outputs.enabled == 'true'
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
-        with:
-          app-id: ${{ secrets.DASCH_BOT_APP_ID }}
-          private-key: ${{ secrets.DASCH_BOT_APP_PRIVATE_KEY }}
-          owner: dasch-swiss
-          repositories: dsp-tools
-          permission-contents: write
-          permission-pull-requests: write
 
       # The script emits pr_url only when it actually opened a PR. No output means
       # versions.env was already current — a no-op, not an error.

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -70,3 +70,105 @@ jobs:
           git add uv.lock
           git commit --allow-empty -m "update uv.lock with new version of dsp-tools"
           git push
+
+  # Release-train leg: merging `chore(start-stack): bump versions to <DSP>` is the
+  # last step before dsp-tools is released, so the release PR it produces is
+  # merged automatically. Any other push to main leaves the release PR open, as
+  # before — releases outside the train stay a deliberate human merge.
+  auto-merge-release-pr:
+    name: Auto-merge release PR (release train only)
+    needs: [release-please]
+    # Kill-switch comparisons enumerate case variants since GitHub Actions
+    # expressions don't have a tolower() function.
+    if: >-
+      github.event_name == 'push'
+      && startsWith(github.event.head_commit.message, 'chore(start-stack): bump versions to')
+      && !contains(fromJSON('["false","False","FALSE"]'), vars.RELEASE_AUTO_MERGE_ENABLED)
+    runs-on: ubuntu-latest
+    # Own group so the merge wait never serialises the release-please job above.
+    concurrency:
+      group: auto-merge-release-pr
+      cancel-in-progress: false
+    steps:
+      - name: Find the release PR (idempotency guard)
+        id: find_pr
+        env:
+          GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # No open release PR means release-please found nothing to release, or a
+          # peer run already merged it — both are no-ops, not errors.
+          release_pr=$(gh pr list --repo "$REPO" --state open --json title,url,headRefName \
+            --jq 'map(select(.title | startswith("chore: release"))) | .[0] // empty')
+          if [[ -z "$release_pr" ]]; then
+            echo "::notice::no open release-please PR, nothing to merge"
+            exit 0
+          fi
+          {
+            echo "pr_url=$(jq -r .url <<<"$release_pr")"
+            echo "branch=$(jq -r .headRefName <<<"$release_pr")"
+            echo "title=$(jq -r .title <<<"$release_pr")"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v7
+        if: steps.find_pr.outputs.pr_url != ''
+        with:
+          ref: ${{ steps.find_pr.outputs.branch }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify the release PR is internally consistent
+        if: steps.find_pr.outputs.pr_url != ''
+        env:
+          PR_TITLE: ${{ steps.find_pr.outputs.title }}
+        run: |
+          set -euo pipefail
+          # release-please derives all three from the same conventional commits, so
+          # disagreement means the PR was hand-edited or a run was interrupted —
+          # never something to merge unattended.
+          title_version="${PR_TITLE#chore: release }"
+          manifest_version=$(jq -r '."."' .github/release-please-manifest.json)
+          pyproject_version=$(grep -m1 '^version = ' pyproject.toml | sed -E 's/^version = "(.*)"/\1/')
+          echo "title=$title_version manifest=$manifest_version pyproject=$pyproject_version"
+          if [[ "$title_version" != "$manifest_version" || "$title_version" != "$pyproject_version" ]]; then
+            echo "::error::version mismatch on the release PR — refusing to merge"
+            exit 1
+          fi
+
+      # contents+pull-requests WRITE on dsp-tools ONLY. The App is a review-bypass
+      # actor on main, which is what lets a bot-authored PR merge without a human
+      # approval. SHA-pinned (v3 == bcd2ba4) since this action handles private-key material.
+      - name: Mint DaSCH Bot App token (write — dsp-tools only)
+        id: app-token
+        if: steps.find_pr.outputs.pr_url != ''
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
+        with:
+          app-id: ${{ secrets.DASCH_BOT_APP_ID }}
+          private-key: ${{ secrets.DASCH_BOT_APP_PRIVATE_KEY }}
+          owner: dasch-swiss
+          repositories: dsp-tools
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Merge the release PR once its checks are green
+        if: steps.find_pr.outputs.pr_url != ''
+        uses: ./.github/actions/merge-pr-when-green
+        with:
+          pr-url: ${{ steps.find_pr.outputs.pr_url }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Notify on failure (internal)
+        if: failure()
+        env:
+          INTERNAL_WEBHOOK: ${{ secrets.GOOGLE_CHAT_DSP_RELEASE_INTERNAL_WEBHOOK_URL }}
+          PR_URL: ${{ steps.find_pr.outputs.pr_url }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          run_url="https://github.com/$REPO/actions/runs/$RUN_ID"
+          text="❌ auto-merge of the dsp-tools release PR (${PR_URL:-unknown}) failed · <$run_url|view run>"
+          curl -fsSL -X POST -H 'Content-Type: application/json' \
+            -d "$(jq -n --arg text "$text" '{text:$text}')" \
+            "$INTERNAL_WEBHOOK"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,8 +15,12 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      # Empty when release-please neither created nor updated a release PR in this run.
+      release_pr_number: ${{ steps.release_pr.outputs.number }}
     steps:
       - uses: googleapis/release-please-action@v5
+        id: release_please
         with:
           # Do not use the default token (GITHUB_TOKEN) for this action,
           # as any actions triggered by the user of this token will not trigger further actions
@@ -28,44 +32,52 @@ jobs:
           token: ${{ secrets.DASCHBOT_PAT }}
           config-file: .github/release-please-config.json
           manifest-file: .github/release-please-manifest.json
-      - name: Get branch of open release-please PR
-        id: get_release_pr_branch
+      # The action itself reports the release PR it just created or updated, so
+      # neither this job nor the one below has to search for it afterwards.
+      # https://github.com/googleapis/release-please-action#outputs
+      - name: Read the release PR reported by release-please
+        id: release_pr
         env:
-          PAT: ${{ secrets.DASCHBOT_PAT }}
+          RELEASE_PR: ${{ steps.release_please.outputs.pr }}
         run: |
-          pr_data=$(curl -s -H "Authorization: token $PAT" \
-            "https://api.github.com/repos/dasch-swiss/dsp-tools/pulls?state=open")
-
-          # iterate over the JSON array with `.[]`, then select PR if title matches condition
-          release_pr=$(echo "$pr_data" | jq '.[] | select(.title | startswith("chore: release"))')
-
-          if [[ -z "$release_pr" ]]; then  # -z exits with code 0 if the string has length 0
-            echo "No open release-please PR found — skipping uv.lock update."
-            echo "branch=" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          echo "release-please pr output: ${RELEASE_PR:-<unset>}"
+          if [[ -z "$RELEASE_PR" ]]; then
+            echo "::notice::release-please created or updated no release PR — skipping uv.lock update"
             exit 0
           fi
-
-          branch_name=$(echo "$release_pr" | jq -r '.head.ref')
-          echo "branch=$branch_name" >> $GITHUB_OUTPUT
+          number=$(jq -r '.number // empty' <<<"$RELEASE_PR")
+          branch=$(jq -r '.headBranchName // empty' <<<"$RELEASE_PR")
+          # Fail here rather than let a bad number reach `gh pr view` or a bad
+          # branch reach `git checkout`, where the error would be cryptic.
+          if [[ ! "$number" =~ ^[0-9]+$ || -z "$branch" ]]; then
+            echo "::error::unexpected shape of the release-please pr output (see the line above)"
+            exit 1
+          fi
+          {
+            echo "number=$number"
+            echo "branch=$branch"
+          } >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v7
-        if: steps.get_release_pr_branch.outputs.branch != ''
+        if: steps.release_pr.outputs.branch != ''
         with:
           fetch-depth: 0
           persist-credentials: false  # Disable default GITHUB_TOKEN credentials
       - name: Install uv
-        if: steps.get_release_pr_branch.outputs.branch != ''
+        if: steps.release_pr.outputs.branch != ''
         uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
       - name: Update uv.lock and commit it
-        if: steps.get_release_pr_branch.outputs.branch != ''
+        if: steps.release_pr.outputs.branch != ''
         env:
           PAT: ${{ secrets.DASCHBOT_PAT }}
+          BRANCH: ${{ steps.release_pr.outputs.branch }}
         run: |
           git config user.name "daschbot"
           git config user.email "daschbot@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${PAT}@github.com/dasch-swiss/dsp-tools.git"
-          git checkout ${{ steps.get_release_pr_branch.outputs.branch }}
+          git checkout "$BRANCH"
           uv lock
           git add uv.lock
           git commit --allow-empty -m "update uv.lock with new version of dsp-tools"
@@ -81,17 +93,19 @@ jobs:
     if: >-
       github.event_name == 'push'
       && startsWith(github.event.head_commit.message, 'chore(start-stack): bump versions to')
+      && needs.release-please.outputs.release_pr_number != ''
     runs-on: ubuntu-latest
     # Own group so the merge wait never serialises the release-please job above.
     concurrency:
       group: auto-merge-release-pr
       cancel-in-progress: false
     steps:
-      - name: Find the release PR (kill switch, idempotency guard)
+      - name: Resolve the release PR (kill switch, idempotency guard)
         id: find_pr
         env:
-          GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ needs.release-please.outputs.release_pr_number }}
           # Evaluated in bash, not in a job-level `if:`, so that both halves of the
           # kill switch normalize case the same way — GitHub Actions expressions
           # have no tolower(), so a job-level check would only catch the casings
@@ -103,12 +117,13 @@ jobs:
             echo "::notice::RELEASE_AUTO_MERGE_ENABLED=false, leaving the release PR for a human to merge"
             exit 0
           fi
-          # No open release PR means release-please found nothing to release, or a
-          # peer run already merged it — both are no-ops, not errors.
-          release_pr=$(gh pr list --repo "$REPO" --state open --json title,url,headRefName \
-            --jq 'map(select(.title | startswith("chore: release"))) | .[0] // empty')
-          if [[ -z "$release_pr" ]]; then
-            echo "::notice::no open release-please PR, nothing to merge"
+          # Read title and branch from the PR itself rather than from the action
+          # output, so the checks below are made against the server's state.
+          release_pr=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state,url,headRefName,title)
+          echo "$release_pr"
+          # Not open means a peer run already merged it — a no-op, not an error.
+          if [[ "$(jq -r .state <<<"$release_pr")" != "OPEN" ]]; then
+            echo "::notice::release PR #$PR_NUMBER is not open, nothing to merge"
             exit 0
           fi
           {

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -78,25 +78,31 @@ jobs:
   auto-merge-release-pr:
     name: Auto-merge release PR (release train only)
     needs: [release-please]
-    # Kill-switch comparisons enumerate case variants since GitHub Actions
-    # expressions don't have a tolower() function.
     if: >-
       github.event_name == 'push'
       && startsWith(github.event.head_commit.message, 'chore(start-stack): bump versions to')
-      && !contains(fromJSON('["false","False","FALSE"]'), vars.RELEASE_AUTO_MERGE_ENABLED)
     runs-on: ubuntu-latest
     # Own group so the merge wait never serialises the release-please job above.
     concurrency:
       group: auto-merge-release-pr
       cancel-in-progress: false
     steps:
-      - name: Find the release PR (idempotency guard)
+      - name: Find the release PR (kill switch, idempotency guard)
         id: find_pr
         env:
           GH_TOKEN: ${{ secrets.DASCHBOT_PAT }}
           REPO: ${{ github.repository }}
+          # Evaluated in bash, not in a job-level `if:`, so that both halves of the
+          # kill switch normalize case the same way — GitHub Actions expressions
+          # have no tolower(), so a job-level check would only catch the casings
+          # it enumerates and could leave this half enabled while the other is off.
+          AUTO_MERGE_ENABLED: ${{ vars.RELEASE_AUTO_MERGE_ENABLED }}
         run: |
           set -euo pipefail
+          if [[ "${AUTO_MERGE_ENABLED,,}" == "false" ]]; then
+            echo "::notice::RELEASE_AUTO_MERGE_ENABLED=false, leaving the release PR for a human to merge"
+            exit 0
+          fi
           # No open release PR means release-please found nothing to release, or a
           # peer run already merged it — both are no-ops, not errors.
           release_pr=$(gh pr list --repo "$REPO" --state open --json title,url,headRefName \

--- a/README.md
+++ b/README.md
@@ -168,6 +168,20 @@ This PR will follow semantic versioning and update the change log.
 Once all desired features are merged, the release can be published by merging this release pull request into `main`. 
 This will trigger actions that create a release on GitHub and on PyPI.
 
+During the weekly DSP release train, these two merges happen without human interaction:
+
+- After a production deployment, `bump-stack-versions.yml` opens the 
+  `chore(start-stack): bump versions to <DSP>` PR and merges it once its required checks are green.
+- That merge is the only push to `main` that makes `release-please.yml` merge the release PR, too, 
+  after verifying that the PR title, `.github/release-please-manifest.json`, and `pyproject.toml` agree on the version. 
+  Every other push to `main` leaves the release PR open, as described above.
+
+Both merges are performed by the DaSCH Bot App, 
+which is a review-bypass actor on `main` (required status checks are never bypassed). 
+Set the repository variable `RELEASE_AUTO_MERGE_ENABLED` to `false` to turn the automation off 
+and go back to merging both PRs by hand. 
+Failures are reported to the internal DSP release Google Chat space.
+
 
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ Both merges are performed by the DaSCH Bot App,
 which is a review-bypass actor on `main` (required status checks are never bypassed). 
 Set the repository variable `RELEASE_AUTO_MERGE_ENABLED` to `false` to turn the automation off 
 and go back to merging both PRs by hand. 
+If the bump PR is ever merged by hand, squash it: 
+the release PR is only picked up when the head commit of `main` still carries the bump PR's title. 
 Failures are reported to the internal DSP release Google Chat space.
 
 

--- a/scripts/bump_stack_versions.py
+++ b/scripts/bump_stack_versions.py
@@ -7,6 +7,10 @@ writes src/dsp_tools/resources/start-stack/versions.env, creates a branch,
 commits, pushes, and opens a pull request. The docker-compose.yml interpolates
 the version values at `docker compose up` time via `--env-file versions.env`.
 
+The URL of the created PR is written to $GITHUB_OUTPUT as `pr_url`, so the
+workflow can merge exactly that PR instead of searching for it afterwards.
+No output means no PR was opened (versions.env was already up to date).
+
 Prerequisites:
 - RELEASE, API, APP, DB env vars must be set
 """
@@ -41,7 +45,9 @@ def main() -> None:
     subprocess.run(["git", "commit", "-m", git_msg], check=True)
     subprocess.run(["git", "push", "-u", "origin", branch_name], check=True)
 
-    subprocess.run(
+    # stdout is captured to get the PR URL; stderr stays inherited so gh's
+    # diagnostics still show up in the CI log if the call fails.
+    result = subprocess.run(
         [
             "gh",
             "pr",
@@ -54,8 +60,29 @@ def main() -> None:
             "",
         ],
         check=True,
+        stdout=subprocess.PIPE,
+        text=True,
     )
-    print(f"Pull request created for branch '{branch_name}'.")
+    pr_url = _parse_pr_url(result.stdout)
+    print(f"Pull request created for branch '{branch_name}': {pr_url}")
+    _write_github_output("pr_url", pr_url)
+
+
+def _parse_pr_url(gh_stdout: str) -> str:
+    # `gh pr create` prints the URL of the new PR as the last line of stdout.
+    lines = [line.strip() for line in gh_stdout.splitlines() if line.strip()]
+    if not lines or not lines[-1].startswith("https://"):
+        print(f"ERROR: could not parse the PR URL from the output of `gh pr create`: {gh_stdout!r}")
+        sys.exit(1)
+    return lines[-1]
+
+
+def _write_github_output(name: str, value: str) -> None:
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if not github_output:  # running outside GitHub Actions
+        return
+    with Path(github_output).open("a", encoding="utf-8") as f:
+        f.write(f"{name}={value}\n")
 
 
 def _get_versions_from_env() -> tuple[str, dict[str, str]]:

--- a/test/unittests/scripts/test_bump_stack_versions.py
+++ b/test/unittests/scripts/test_bump_stack_versions.py
@@ -1,7 +1,11 @@
+from pathlib import Path
+
 import pytest
 
 from scripts.bump_stack_versions import _get_versions_from_env
+from scripts.bump_stack_versions import _parse_pr_url
 from scripts.bump_stack_versions import _require_env
+from scripts.bump_stack_versions import _write_github_output
 
 
 class TestRequireEnv:
@@ -69,3 +73,31 @@ class TestGetVersionsFromEnv:
         monkeypatch.setenv("DB", "5.5.0-3")
         with pytest.raises(SystemExit):
             _get_versions_from_env()
+
+
+class TestParsePrUrl:
+    def test_takes_the_url_from_the_last_line(self) -> None:
+        stdout = "Warning: 1 uncommitted change\nhttps://github.com/dasch-swiss/dsp-tools/pull/2392\n"
+        assert _parse_pr_url(stdout) == "https://github.com/dasch-swiss/dsp-tools/pull/2392"
+
+    def test_exits_when_no_url(self) -> None:
+        with pytest.raises(SystemExit):
+            _parse_pr_url("Creating pull request for chore/bump-version-2026.03.04 into main\n")
+
+    def test_exits_when_empty(self) -> None:
+        with pytest.raises(SystemExit):
+            _parse_pr_url("")
+
+
+class TestWriteGithubOutput:
+    def test_appends_key_value(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        output_file = tmp_path / "github_output"
+        output_file.write_text("existing=value\n", encoding="utf-8")
+        monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+        _write_github_output("pr_url", "https://github.com/dasch-swiss/dsp-tools/pull/2392")
+        expected = "existing=value\npr_url=https://github.com/dasch-swiss/dsp-tools/pull/2392\n"
+        assert output_file.read_text(encoding="utf-8") == expected
+
+    def test_is_a_no_op_outside_github_actions(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+        _write_github_output("pr_url", "https://github.com/dasch-swiss/dsp-tools/pull/2392")


### PR DESCRIPTION
[DEV-6956](https://linear.app/dasch/issue/DEV-6956)

## Summary

- The two release-train follow-on PRs in this repo — `chore(start-stack): bump versions to <DSP>` and the release-please `chore: release x.y.z` — were merged by hand. They are now merged by the DaSCH Bot App once their required checks are green, mirroring `dsp-docs/.github/workflows/bump-release.yml`.
- The release PR is merged **only** when the push that produced it is the start-stack bump commit. Releases outside the release train stay a deliberate human merge, exactly as today.
- Both merges are guarded by a kill switch, an idempotency check, a concurrency group, and a failure notification to the internal Google Chat webhook.
- Neither leg searches for the PR it merges: each is told which PR it is by whatever created it.

## Changes

**New composite action** — `.github/actions/merge-pr-when-green/action.yml`

Retries `gh pr merge --squash --admin` until the required checks pass (30 min budget, 30 s poll), refreshing the branch only when the merge output says it is behind base. GitHub's native auto-merge is unusable here: it waits for a real approval that never comes on a bot-authored PR. The App is a bypass actor for the *review* only — required status checks have no per-actor bypass, so the merge is rejected by the server until CI is green and can never happen before it.

**`bump-stack-versions.yml`** — `scripts/bump_stack_versions.py` now writes the URL that `gh pr create` returns to `$GITHUB_OUTPUT`, and the workflow merges exactly that PR. The script also opens the PR with the App token instead of `DASCHBOT_PAT`: an App installation token triggers workflow runs just like the PAT does (only the default `GITHUB_TOKEN` does not), so the required checks still run on the bump PR — and this workflow no longer touches the long-lived PAT. No `pr_url` output means the script no-opped, which is treated as a no-op, not an error. Added a per-release concurrency group and a failure notification.

**`release-please.yml`** — new `auto-merge-release-pr` job, gated on `startsWith(head_commit.message, 'chore(start-stack): bump versions to')`. The release PR comes from the release-please action's own `pr` output, whose number is then resolved with `gh pr view`; the pre-existing curl lookup that searched open PRs by title prefix (and its PAT usage) is gone with it. Before merging, the job verifies that the PR title, `.github/release-please-manifest.json` and `pyproject.toml` agree on the version; release-please derives all three from the same conventional commits, so disagreement means the PR was hand-edited or a run was interrupted. The job has its own concurrency group so the merge wait never serialises the release-please job above it.

**`README.md`** — documents the automated behaviour, the `RELEASE_AUTO_MERGE_ENABLED` kill switch, and that a manual fallback merge of the bump PR must be a squash merge.

## Required configuration (not in this diff)

1. Add `dsp-tools` to the DaSCH Bot App installation (contents + pull-requests, write) — org owner, GitHub UI.
2. Add the App as a review-bypass actor in `dsp-tools` branch protection on `main`, mirroring `dsp-docs`. Review bypass only — the 13 required status checks are never bypassed, and `enforce_admins` stays on.

Step 1 must come first: GitHub rejects a bypass allowance for an App that is not installed on the repo. Since the App now also opens the bump PR, step 1 is a hard prerequisite for `bump-stack-versions.yml` as a whole — without it the run fails at token minting, before a PR exists.

## Test Plan

- `just yamllint` clean (only the pre-existing `publish-release-to-pypi.yml` line-length warning remains); `just ruff-check`, `just ruff-format-check` and `mypy` clean.
- `pytest test/unittests/scripts/` — unit tests cover the new PR-URL parsing and the `$GITHUB_OUTPUT` write.
- Every embedded shell block extracted and syntax-checked with `bash -n`.
- The version-agreement check was run against the real `release-please-manifest.json` / `pyproject.toml` (`19.0.0`), and against a deliberately mismatched title — matches and rejects as expected.
- The `gh pr view` resolution and its not-open guard were run read-only against the live merged release PR #2389.
- Neither workflow runs on `pull_request`, so the automation itself is first exercised on the next release train. The raw release-please `pr` output is echoed to the log, so its exact shape is visible on that first run. `RELEASE_AUTO_MERGE_ENABLED=false` reverts to the current manual merging without a revert PR.
