### PR TITLE
chore: improve log level for HTTP status "accepted" and "no content"

### DIFF
--- a/src/dsp_tools/utils/request_utils.py
+++ b/src/dsp_tools/utils/request_utils.py
@@ -144,7 +144,10 @@ def log_response(response: Response, status_code: int, include_response_content:
     else:
         dumpobj["content"] = "too big to be logged"
     log_str = f"RESPONSE: {json.dumps(dumpobj)}"
-    if status_code == HTTPStatus.OK:
+
+    debug_log_levels = [HTTPStatus.OK, HTTPStatus.ACCEPTED, HTTPStatus.NO_CONTENT]
+
+    if status_code in debug_log_levels:
         logger.debug(log_str)
     else:
         logger.warning(log_str)


### PR DESCRIPTION
- Currently we log everything that is not 200 with level warning
- In `dsp-tools migration` we get responses of 202 and 204 which are perfectly expected and acceptable
- Because it is not 200 they were included in the warnings.log file where they do not belong
- This PR includes those response codes in the debug level