### PR TITLE
fix(xmllib): only initialise warnings CSV when xmllib is actually used (DEV-6992)

### DIFF
--- a/src/dsp_tools/xmllib/__init__.py
+++ b/src/dsp_tools/xmllib/__init__.py
@@ -1,5 +1,3 @@
-from dsp_tools.xmllib.internal.xmllib_warnings_util import initialise_warning_file
-
 from .general_functions import ListLookup as ListLookup
 from .general_functions import clean_whitespaces_from_string as clean_whitespaces_from_string
 from .general_functions import create_footnote_element as create_footnote_element
@@ -47,5 +45,3 @@ from .value_converters import reformat_date as reformat_date
 from .value_converters import replace_newlines_with_br_tags as replace_newlines_with_br_tags
 from .value_converters import replace_newlines_with_paragraph_tags as replace_newlines_with_paragraph_tags
 from .value_converters import replace_newlines_with_tags as replace_newlines_with_tags
-
-initialise_warning_file()

--- a/src/dsp_tools/xmllib/internal/xmllib_warnings_util.py
+++ b/src/dsp_tools/xmllib/internal/xmllib_warnings_util.py
@@ -20,8 +20,14 @@ from dsp_tools.xmllib.internal.xmllib_warnings import XmllibInputWarning
 read_dotenv_if_exists()
 
 
+class _WarningFileState:
+    initialised = False
+
+
 def initialise_warning_file() -> None:
-    """Initialise warnings file if the user configured it."""
+    """Initialise warnings file if the user configured it. Safe to call more than once per process."""
+    if _WarningFileState.initialised:
+        return
     if file_path := os.getenv("XMLLIB_WARNINGS_CSV_SAVEPATH"):
         try:
             new_row = ["File", "Severity", "Message", "Resource ID", "Property", "Field"]
@@ -39,12 +45,14 @@ def initialise_warning_file() -> None:
                 f"The filepath '{file_path}' you entered in your .env file does not exist. "
                 f"Please ensure that the folder you named exists."
             ) from None
+    _WarningFileState.initialised = True
 
 
 def write_message_to_csv(
     file_path: str, msg: MessageInfo, function_trace: str | None, severity: UserMessageSeverity
 ) -> None:
     """Write the message to the csv."""
+    initialise_warning_file()
     new_row = [
         function_trace if function_trace else "",
         str(severity),

--- a/src/dsp_tools/xmllib/models/root.py
+++ b/src/dsp_tools/xmllib/models/root.py
@@ -268,8 +268,8 @@ class XMLRoot:
             f.write(xml_string)
             print(f"The XML file was successfully saved to {filepath}.")
         if file_path := os.getenv("XMLLIB_WARNINGS_CSV_SAVEPATH"):
-            df = pd.read_csv(file_path)
-            if len(df) > 0:
+            # The file only exists if a warning was actually written to it during the run.
+            if Path(file_path).is_file() and len(df := pd.read_csv(file_path)) > 0:
                 msg = f"{len(df)} warnings occurred, please consult '{file_path}' for details."
                 print(BOLD_RED, msg, RESET_TO_DEFAULT)
             else:

--- a/test/unittests/error/test_xmllib_warnings_util.py
+++ b/test/unittests/error/test_xmllib_warnings_util.py
@@ -2,7 +2,9 @@ import pandas as pd
 import pytest
 import regex
 
+from dsp_tools.xmllib.internal import xmllib_warnings_util
 from dsp_tools.xmllib.internal.xmllib_warnings import MessageInfo
+from dsp_tools.xmllib.internal.xmllib_warnings import UserMessageSeverity
 from dsp_tools.xmllib.internal.xmllib_warnings import XmllibInputInfo
 from dsp_tools.xmllib.internal.xmllib_warnings import XmllibInputWarning
 from dsp_tools.xmllib.internal.xmllib_warnings_util import _filter_stack_frames
@@ -12,11 +14,20 @@ from dsp_tools.xmllib.internal.xmllib_warnings_util import emit_xmllib_input_inf
 from dsp_tools.xmllib.internal.xmllib_warnings_util import emit_xmllib_input_type_mismatch_warning
 from dsp_tools.xmllib.internal.xmllib_warnings_util import emit_xmllib_input_warning
 from dsp_tools.xmllib.internal.xmllib_warnings_util import get_user_message_string
+from dsp_tools.xmllib.internal.xmllib_warnings_util import initialise_warning_file
+from dsp_tools.xmllib.internal.xmllib_warnings_util import write_message_to_csv
 
 
 @pytest.fixture
 def message_info():
     return MessageInfo("msg", "id")
+
+
+@pytest.fixture(autouse=True)
+def _reset_warning_file_initialised():
+    xmllib_warnings_util._WarningFileState.initialised = False
+    yield
+    xmllib_warnings_util._WarningFileState.initialised = False
 
 
 def test_emit_xmllib_input_info(message_info):
@@ -38,6 +49,42 @@ def test_emit_xmllib_input_type_mismatch_warning():
     )
     with pytest.warns(XmllibInputWarning, match=expected):
         emit_xmllib_input_type_mismatch_warning(expected_type="string", value=pd.NA, res_id="id", value_field="field")
+
+
+class TestInitialiseWarningFile:
+    def test_creates_file_with_header(self, tmp_path, monkeypatch):
+        csv_path = tmp_path / "warnings.csv"
+        monkeypatch.setenv("XMLLIB_WARNINGS_CSV_SAVEPATH", str(csv_path))
+        initialise_warning_file()
+        assert csv_path.read_text().splitlines() == ["File,Severity,Message,Resource ID,Property,Field"]
+
+    def test_second_call_is_a_no_op(self, tmp_path, monkeypatch, capsys):
+        csv_path = tmp_path / "warnings.csv"
+        monkeypatch.setenv("XMLLIB_WARNINGS_CSV_SAVEPATH", str(csv_path))
+        initialise_warning_file()
+        capsys.readouterr()
+        csv_path.write_text(csv_path.read_text() + "trace,WARNING,msg,id,,\n")
+        initialise_warning_file()
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert len(csv_path.read_text().splitlines()) == 2
+
+
+class TestWriteMessageToCsv:
+    def test_triggers_initialisation_before_appending(self, tmp_path, monkeypatch, message_info):
+        csv_path = tmp_path / "warnings.csv"
+        monkeypatch.setenv("XMLLIB_WARNINGS_CSV_SAVEPATH", str(csv_path))
+        write_message_to_csv(str(csv_path), message_info, None, UserMessageSeverity.WARNING)
+        lines = csv_path.read_text().splitlines()
+        assert lines[0] == "File,Severity,Message,Resource ID,Property,Field"
+        assert lines[1] == ",WARNING,msg,id,,"
+
+    def test_does_not_reinitialise_on_second_call(self, tmp_path, monkeypatch, message_info):
+        csv_path = tmp_path / "warnings.csv"
+        monkeypatch.setenv("XMLLIB_WARNINGS_CSV_SAVEPATH", str(csv_path))
+        write_message_to_csv(str(csv_path), message_info, None, UserMessageSeverity.WARNING)
+        write_message_to_csv(str(csv_path), message_info, None, UserMessageSeverity.INFO)
+        assert len(csv_path.read_text().splitlines()) == 3
 
 
 class TestGetMessageString:

--- a/test/unittests/xmllib/models/test_root.py
+++ b/test/unittests/xmllib/models/test_root.py
@@ -387,6 +387,19 @@ def _authorship_by_id(serialised: etree._Element) -> dict[str, list[str | None]]
     return lookup
 
 
+class TestWriteFile:
+    def test_reports_no_warnings_when_warnings_file_was_never_written(self, tmp_path, monkeypatch, capsys) -> None:
+        csv_path = tmp_path / "warnings.csv"
+        monkeypatch.setenv("XMLLIB_WARNINGS_CSV_SAVEPATH", str(csv_path))
+        out_file = tmp_path / "out.xml"
+        root = XMLRoot.create_new("0000", "test")
+        root.add_resource(Resource.create_new("id_1", ":ResType", "lbl"))
+        root.write_file(out_file)
+        assert not csv_path.is_file()
+        captured = capsys.readouterr()
+        assert "No warnings occurred during the runtime." in captured.out
+
+
 class TestApplyDefaultResourceAuthorship:
     def test_literal_normalised_on_create(self) -> None:
         root = XMLRoot.create_new("0000", "test", apply_default_resource_authorship=["B", "A"])


### PR DESCRIPTION
## Summary
- `initialise_warning_file()` used to run unconditionally at `xmllib` package-import time, and importing `dsp_tools` at all (e.g. for `start-stack`/`stop-stack`) transitively imports `xmllib` — so the CSV-redirection banner printed on every `dsp-tools` invocation whenever `XMLLIB_WARNINGS_CSV_SAVEPATH` was set, regardless of the command.
- Made `initialise_warning_file()` idempotent and call it lazily from `write_message_to_csv()` — the only function that ever appends a warning row — so it now only fires on the first actual warning/error/info emitted by an xmllib script.
- Guarded `XMLRoot.write_file()`'s CSV read with a `Path(file_path).is_file()` check, since a missing file now correctly means "zero warnings occurred" instead of assuming the file was always pre-created.
- Removed the eager `initialise_warning_file()` call and its import from `xmllib/__init__.py`.

Fixes DEV-6992.

## Test plan
- [x] `just ruff-check`, `just ruff-format-check`, `just mypy`, `just vulture` all pass
- [x] `test/unittests` (2768 passed) and `test/integration/xmllib` (8 passed) pass
- [x] Manually verified: `dsp-tools --version` with `XMLLIB_WARNINGS_CSV_SAVEPATH` set in `.env` no longer prints the banner
- [x] Manually verified: a real xmllib script that emits a warning still prints the banner once and produces a correct CSV summary in `write_file()`