### PR TITLE
chore: stop emitting docs.dasch.swiss/latest links (DEV-6966)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ This document is intended for developers who want to work with the code of DSP-T
 
 > [!NOTE]
 > This technical document was written as a guide for developers.
-> For the end user documentation, please consult [https://docs.dasch.swiss](https://docs.dasch.swiss/latest/DSP-TOOLS).
+> For the end user documentation, please consult [https://docs.dasch.swiss](https://docs.dasch.swiss/DSP-TOOLS).
  
 > [!TIP]
 > This README contains basic information for getting started. 
-> More details can be found in the [developers' documentation](https://docs.dasch.swiss/latest/DSP-TOOLS/developers/).
+> More details can be found in the [developers' documentation](https://docs.dasch.swiss/DSP-TOOLS/developers/).
 
 
 
@@ -73,7 +73,7 @@ Then run `/mcp` inside Claude Code to trigger the login.
 
 Curious what uv is and why we use it? 
 Check out the respective section in the
-[developers' documentation](https://docs.dasch.swiss/latest/DSP-TOOLS/developers/packaging/).
+[developers' documentation](https://docs.dasch.swiss/DSP-TOOLS/developers/packaging/).
 
 If you want to work on the code of DSP-TOOLS, you first have to do the following:
 
@@ -162,7 +162,7 @@ This multi-layered approach ensures compatibility without adding overhead to PRs
 
 Publishing is automated with GitHub Actions. 
 Please follow the 
-[Pull Request Guidelines](https://docs.dasch.swiss/latest/developers/contribution/#pull-request-guidelines). 
+[Pull Request Guidelines](https://docs.dasch.swiss/developers/contribution/#pull-request-guidelines). 
 When merging a pull request into `main`, the `release-please` action will create or update a release PR. 
 This PR will follow semantic versioning and update the change log. 
 Once all desired features are merged, the release can be published by merging this release pull request into `main`. 
@@ -212,7 +212,7 @@ The following are self-contained and can be run without further requirements:
 
 The following need a DSP stack running in the background.
 A DSP stack can be started with the command 
-[`dsp-tools start-stack`](https://docs.dasch.swiss/latest/DSP-TOOLS/cli-commands/#start-stack).
+[`dsp-tools start-stack`](https://docs.dasch.swiss/DSP-TOOLS/cli-commands/#start-stack).
 
 - `test/legacy-e2e`
   
@@ -333,14 +333,14 @@ by embedding all three repositories as git submodules
 into the central [dsp-docs](https://github.com/dasch-swiss/dsp-docs) repository.
 If conflicting, the configurations of dsp-docs will override the configurations of the dsp-tools repository.
 In rare cases, a certain syntax may be correctly rendered locally, 
-but not on <https://docs.dasch.swiss/latest/DSP-TOOLS>. 
+but not on <https://docs.dasch.swiss/DSP-TOOLS>. 
 In order to keep this difference minimal, 
 `mkdocs.yml` of dsp-tools should be as close as possible to the `mkdocs.yml` of dsp-docs.
 
 During the centralized deployment process of all components of the DSP software stack,
-the docs of dsp-tools get built from the latest release tag to <https://docs.dasch.swiss/latest/DSP-TOOLS>.
+the docs of dsp-tools get built from the latest release tag to <https://docs.dasch.swiss/DSP-TOOLS>.
 
-This means that in order to modify the contents of <https://docs.dasch.swiss/latest/DSP-TOOLS>, 
+This means that in order to modify the contents of <https://docs.dasch.swiss/DSP-TOOLS>, 
 it is necessary to:
 
 - Merge the modifications into the main branch of the dsp-tools repository,

--- a/docs/data-file/excel2xml-module.md
+++ b/docs/data-file/excel2xml-module.md
@@ -375,5 +375,5 @@ The function `find_dates_in_string(string)` tries to find calendar dates in a st
 If successful, it returns the DSP-formatted date strings.
 
 This function is a redirection to [`xmllib.find_dates_in_string()`](
-https://docs.dasch.swiss/latest/DSP-TOOLS/xmllib-docs/general-functions/#xmllib.general_functions.find_dates_in_string).
+https://docs.dasch.swiss/DSP-TOOLS/xmllib-docs/general-functions/#xmllib.general_functions.find_dates_in_string).
 See there for more information.

--- a/docs/data-file/xml-data-file.md
+++ b/docs/data-file/xml-data-file.md
@@ -374,7 +374,7 @@ Supported file extensions:
 | `StillImageRepresentation`  | JPG, JPEG, PNG, TIF, TIFF, JP2, SVG                |
 | `TextRepresentation`        | TXT, CSV, XML, HTM, HTML, XSL, XSD, ODD, RNG, JSON |
 
-For more details, please consult the [API docs](https://docs.dasch.swiss/latest/DSP-API/01-introduction/file-formats/).
+For more details, please consult the [API docs](https://docs.dasch.swiss/DSP-API/01-introduction/file-formats/).
 
 Attributes:
 
@@ -900,7 +900,7 @@ The `<text>` element has the following attributes:
 - `encoding` (required)
     - `utf8`: To be used for `SimpleText` and `Textarea` properties.
     - `xml`: To be used for `Richtext` properties. It must follow the XML format as defined by the
-  [DSP standard mapping](https://docs.dasch.swiss/latest/DSP-API/03-endpoints/api-v2/text/standard-standoff/).
+  [DSP standard mapping](https://docs.dasch.swiss/DSP-API/03-endpoints/api-v2/text/standard-standoff/).
 - `permissions`: Permission ID (optional)
 - `comment`: a comment for this specific value (optional)
 - `order`: display order relative to other values of the same property (optional, see [Value Order](#value-order))

--- a/docs/data-model/json-project/ontologies.md
+++ b/docs/data-model/json-project/ontologies.md
@@ -523,7 +523,7 @@ A short overview how to choose the most suitable `TextValue` type for a particul
         - Must not contain formatting or mark-up of any kind (XML, HTML, markdown, etc.).
 - `Richtext`
     - Suitable for a longer text containing the 
-      [DSP standard mark-up](https://docs.dasch.swiss/latest/DSP-API/03-endpoints/api-v2/text/standard-standoff/).
+      [DSP standard mark-up](https://docs.dasch.swiss/DSP-API/03-endpoints/api-v2/text/standard-standoff/).
     - Please note that `Richtext` values use much more space in the database than the other types. 
       To economize space in the database, we advise to use it only if mark-up is required.
     - Specifics:

--- a/docs/data-model/json-project/overview.md
+++ b/docs/data-model/json-project/overview.md
@@ -205,7 +205,7 @@ Only licenses that exist in DSP can be enabled. They must be referenced by their
 For example: `http://rdfh.ch/licenses/cc-by-4.0` is a valid license IRI.
 All the licenses listed here will be enabled. Licenses can be disabled by omitting them.
 
-See [the API documentation for details](https://docs.dasch.swiss/latest/DSP-API/01-introduction/legal-info/#license).
+See [the API documentation for details](https://docs.dasch.swiss/DSP-API/01-introduction/legal-info/#license).
 
 
 ### `data_license`

--- a/docs/special-workflows/update-legal.md
+++ b/docs/special-workflows/update-legal.md
@@ -110,7 +110,7 @@ For each multimedia resource, one or more of these errors may occur:
 4. license not parseable
     - If license information is present, 
       an attempt is made to parse it using [`xmllib.find_license_in_string()`](
-      https://docs.dasch.swiss/latest/DSP-TOOLS/xmllib-docs/general-functions/#xmllib.general_functions.find_license_in_string)
+      https://docs.dasch.swiss/DSP-TOOLS/xmllib-docs/general-functions/#xmllib.general_functions.find_license_in_string)
 
 If there were errors, you will get 2 output files:
 
@@ -164,7 +164,7 @@ CSV Output:
 
 Please add a valid license to the CSV, either as IRI or in one of the formats understood by 
 [`xmllib.find_license_in_string()`](
-https://docs.dasch.swiss/latest/DSP-TOOLS/xmllib-docs/general-functions/#xmllib.general_functions.find_license_in_string):
+https://docs.dasch.swiss/DSP-TOOLS/xmllib-docs/general-functions/#xmllib.general_functions.find_license_in_string):
 
 | file     | resource_id | license | copyright | authorship_1  | authorship_2 |
 | -------- | ----------- | ------- | --------- | ------------- | ------------ |

--- a/docs/xmllib-docs/overview.md
+++ b/docs/xmllib-docs/overview.md
@@ -145,7 +145,7 @@ See the [documentation](./resource.md) for all options.
 ### Reformatting the Input With Conversion Functions
 
 We provide a number of functions to help convert your input. For example DSP requires a special format for dates. 
-[Reformat](https://docs.dasch.swiss/latest/DSP-TOOLS/xmllib-docs/value-converters/#xmllib.value_converters.reformat_date) 
+[Reformat](https://docs.dasch.swiss/DSP-TOOLS/xmllib-docs/value-converters/#xmllib.value_converters.reformat_date) 
 your input into the correct format.
 
 ```python

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 ---
 
 site_name: DSP-TOOLS
-site_url: https://docs.dasch.swiss/latest/DSP-TOOLS
+site_url: https://docs.dasch.swiss/DSP-TOOLS
 repo_url: https://github.com/dasch-swiss/dsp-tools
 repo_name: dasch-swiss/dsp-tools
 edit_uri: blob/main/docs/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://www.dasch.swiss/"
-Documentation = "https://docs.dasch.swiss/latest/DSP-TOOLS/"
+Documentation = "https://docs.dasch.swiss/DSP-TOOLS/"
 Repository = "https://github.com/dasch-swiss/dsp-tools.git"
 
 

--- a/scripts/validate_xmllib_docstring_links.py
+++ b/scripts/validate_xmllib_docstring_links.py
@@ -109,7 +109,7 @@ def _find_urls_in_docstrings(directory: Path) -> list[LinkReference]:
 
 
 def _categorize_url(url: str) -> LinkCategory:
-    if "docs.dasch.swiss/latest/DSP-TOOLS/" in url:
+    if "docs.dasch.swiss/DSP-TOOLS/" in url:
         return LinkCategory.DSP_TOOLS_INTERNAL
     else:
         return LinkCategory.EXTERNAL

--- a/src/dsp_tools/commands/excel2xml/excel2xml_lib.py
+++ b/src/dsp_tools/commands/excel2xml/excel2xml_lib.py
@@ -76,7 +76,7 @@ def make_root(
         >>> root = excel2xml.make_root(shortcode=shortcode, default_ontology=default_ontology)
         >>> root = excel2xml.append_permissions(root)
 
-    See https://docs.dasch.swiss/latest/DSP-TOOLS/file-formats/xml-data-file/#the-root-element-knora
+    See https://docs.dasch.swiss/DSP-TOOLS/file-formats/xml-data-file/#the-root-element-knora
     """
     schema_url = "https://raw.githubusercontent.com/dasch-swiss/dsp-tools/main/src/dsp_tools/resources/schema/data.xsd"
     schema_location_key = str(etree.QName("http://www.w3.org/2001/XMLSchema-instance", "schemaLocation"))
@@ -108,7 +108,7 @@ def append_permissions(root_element: etree._Element) -> etree._Element:
         >>> root = excel2xml.make_root(shortcode=shortcode, default_ontology=default_ontology)
         >>> root = excel2xml.append_permissions(root)
 
-    See https://docs.dasch.swiss/latest/DSP-TOOLS/file-formats/xml-data-file/#describing-permissions-with-permissions-elements
+    See https://docs.dasch.swiss/DSP-TOOLS/file-formats/xml-data-file/#describing-permissions-with-permissions-elements
     """
 
     PERMISSIONS = E.permissions
@@ -166,7 +166,7 @@ def make_resource(  # noqa: D417 (undocumented-param)
         >>> resource.append(excel2xml.make_text_prop(...))
         >>> root.append(resource)
 
-    See https://docs.dasch.swiss/latest/DSP-TOOLS/file-formats/xml-data-file/#describing-resources-with-the-resource-element
+    See https://docs.dasch.swiss/DSP-TOOLS/file-formats/xml-data-file/#describing-resources-with-the-resource-element
     """
     if not check_notna(label):
         msg = f"Your resource's label looks suspicious (resource with id '{id}' and label '{label}')"
@@ -221,7 +221,7 @@ def make_bitstream_prop(
         >>> resource.append(excel2xml.make_bitstream_prop("data/images/tree.jpg"))
         >>> root.append(resource)
 
-    See https://docs.dasch.swiss/latest/DSP-TOOLS/file-formats/xml-data-file/#bitstream
+    See https://docs.dasch.swiss/DSP-TOOLS/file-formats/xml-data-file/#bitstream
     """
 
     if check and not Path(path).is_file():
@@ -346,7 +346,7 @@ def make_boolean_prop(
                     <boolean permissions="private" comment="example">true</boolean>
                 </boolean-prop>
 
-    See https://docs.dasch.swiss/latest/DSP-TOOLS/file-formats/xml-data-file/#boolean-prop
+    See https://docs.dasch.swiss/DSP-TOOLS/file-formats/xml-data-file/#boolean-prop
     """
 
     # validate input
@@ -414,7 +414,7 @@ def make_color_prop(
                     <color permissions="public">#000000</color>
                 </color-prop>
 
-    See https://docs.dasch.swiss/latest/DSP-TOOLS/file-formats/xml-data-file/#color-prop
+    See https://docs.dasch.swiss/DSP-TOOLS/file-formats/xml-data-file/#color-prop
     """
 
     # check the input: prepare a list with valid values
@@ -491,7 +491,7 @@ def make_date_prop(
                     </date>
                 </date-prop>
 
-    See https://docs.dasch.swiss/latest/DSP-TOOLS/file-formats/xml-data-file/#date-prop
+    See https://docs.dasch.swiss/DSP-TOOLS/file-formats/xml-data-file/#date-prop
     """
 
     # check the input: prepare a list with valid values
@@ -563,7 +563,7 @@ def make_decimal_prop(
                     <decimal permissions="public">2.718</decimal>
                 </decimal-prop>
 
-    See https://docs.dasch.swiss/latest/DSP-TOOLS/file-formats/xml-data-file/#decimal-prop
+    See https://docs.dasch.swiss/DSP-TOOLS/file-formats/xml-data-file/#decimal-prop
     """
 
     # check the input: prepare a list with valid values
@@ -636,7 +636,7 @@ def make_geometry_prop(
                     <geometry permissions="public">{JSON}</geometry>
                 </geometry-prop>
 
-    See https://docs.dasch.swiss/latest/DSP-TOOLS/file-formats/xml-data-file/#geometry-prop
+    See https://docs.dasch.swiss/DSP-TOOLS/file-formats/xml-data-file/#geometry-prop
     """
 
     # check the input: prepare a list with valid values
@@ -721,7 +721,7 @@ def make_geoname_prop(
                     <geoname permissions="public">1010101</geoname>
                 </geoname-prop>
 
-    See https://docs.dasch.swiss/latest/DSP-TOOLS/file-formats/xml-data-file/#geoname-prop
+    See https://docs.dasch.swiss/DSP-TOOLS/file-formats/xml-data-file/#geoname-prop
     """
 
     # check the input: prepare a list with valid values
@@ -793,7 +793,7 @@ def make_integer_prop(
                     <integer permissions="public">1010101</integer>
                 </integer-prop>
 
-    See https://docs.dasch.swiss/latest/DSP-TOOLS/file-formats/xml-data-file/#integer-prop
+    See https://docs.dasch.swiss/DSP-TOOLS/file-formats/xml-data-file/#integer-prop
     """
 
     # check the input: prepare a list with valid values
@@ -868,7 +868,7 @@ def make_list_prop(
                     <list permissions="public">second_node</list>
                 </list-prop>
 
-    See https://docs.dasch.swiss/latest/DSP-TOOLS/file-formats/xml-data-file/#list-prop
+    See https://docs.dasch.swiss/DSP-TOOLS/file-formats/xml-data-file/#list-prop
     """
 
     # check the input: prepare a list with valid values
@@ -940,7 +940,7 @@ def make_resptr_prop(
                     <resptr permissions="public">resource_2</resptr>
                 </resptr-prop>
 
-    See https://docs.dasch.swiss/latest/DSP-TOOLS/file-formats/xml-data-file/#resptr-prop
+    See https://docs.dasch.swiss/DSP-TOOLS/file-formats/xml-data-file/#resptr-prop
     """
 
     # check the input: prepare a list with valid values
@@ -1013,7 +1013,7 @@ def make_text_prop(
                     <text encoding="utf8" permissions="public">second text</text>
                 </text-prop>
 
-    See https://docs.dasch.swiss/latest/DSP-TOOLS/file-formats/xml-data-file/#text-prop
+    See https://docs.dasch.swiss/DSP-TOOLS/file-formats/xml-data-file/#text-prop
     """
 
     # check the input: prepare a list with valid values
@@ -1084,7 +1084,7 @@ def _escape_reserved_chars(text: str) -> str:
     From richtext strings (encoding="xml"), escape the reserved characters <, > and &,
     but only if they are not part of a standard standoff tag or escape sequence.
     The standard standoff tags allowed by DSP-API are documented here:
-    https://docs.dasch.swiss/2023.12.01/DSP-API/03-endpoints/api-v2/text/standard-standoff/
+    https://docs.dasch.swiss/DSP-API/03-endpoints/api-v2/text/standard-standoff/
 
     Args:
         text: the richtext string to be escaped
@@ -1172,7 +1172,7 @@ def make_time_prop(
                     </time>
                 </time-prop>
 
-    See https://docs.dasch.swiss/latest/DSP-TOOLS/file-formats/xml-data-file/#time-prop
+    See https://docs.dasch.swiss/DSP-TOOLS/file-formats/xml-data-file/#time-prop
     """
 
     # check the input: prepare a list with valid values
@@ -1244,7 +1244,7 @@ def make_uri_prop(
                     <uri permissions="public">www.2.com</uri>
                 </uri-prop>
 
-    See https://docs.dasch.swiss/latest/DSP-TOOLS/file-formats/xml-data-file/#uri-prop
+    See https://docs.dasch.swiss/DSP-TOOLS/file-formats/xml-data-file/#uri-prop
     """
 
     # check the input: prepare a list with valid values
@@ -1310,7 +1310,7 @@ def make_region(  # noqa: D417 (undocumented-param)
         >>> region.append(excel2xml.make_geometry_prop("hasGeometry", "{...}"))
         >>> root.append(region)
 
-    See https://docs.dasch.swiss/latest/DSP-TOOLS/file-formats/xml-data-file/#region
+    See https://docs.dasch.swiss/DSP-TOOLS/file-formats/xml-data-file/#region
     """
 
     kwargs = {"label": label, "id": id, "permissions": permissions, "nsmap": xml_namespace_map}
@@ -1365,7 +1365,7 @@ def make_link(  # noqa: D417 (undocumented-param)
         >>> link.append(excel2xml.make_resptr_prop("hasLinkTo", ["resource_0", "resource_1"]))
         >>> root.append(link)
 
-    See https://docs.dasch.swiss/latest/DSP-TOOLS/file-formats/xml-data-file/#link
+    See https://docs.dasch.swiss/DSP-TOOLS/file-formats/xml-data-file/#link
     """
 
     kwargs = {"label": label, "id": id, "permissions": permissions, "nsmap": xml_namespace_map}
@@ -1413,7 +1413,7 @@ def make_audio_segment(  # noqa: D417 (undocumented-param)
         >>> audio_segment.append(excel2xml.make_hasSegmentBounds_prop(segment_start=60, segment_end=120)
         >>> root.append(audio_segment)
 
-    See https://docs.dasch.swiss/latest/DSP-TOOLS/file-formats/xml-data-file/#video-segment-audio-segment
+    See https://docs.dasch.swiss/DSP-TOOLS/file-formats/xml-data-file/#video-segment-audio-segment
     """
     return etree.Element(
         "{%s}audio-segment" % xml_namespace_map[None],
@@ -1445,7 +1445,7 @@ def make_video_segment(  # noqa: D417 (undocumented-param)
         >>> video_segment.append(excel2xml.make_hasSegmentBounds_prop(segment_start=60, segment_end=120)
         >>> root.append(video_segment)
 
-    See https://docs.dasch.swiss/latest/DSP-TOOLS/file-formats/xml-data-file/#video-segment-audio-segment
+    See https://docs.dasch.swiss/DSP-TOOLS/file-formats/xml-data-file/#video-segment-audio-segment
     """
     return etree.Element(
         "{%s}video-segment" % xml_namespace_map[None],
@@ -1930,7 +1930,7 @@ def write_xml(
     """
     warn_msg = (
         "The excel2xml lib is deprecated in favor of the xmllib. It will be removed in a future release.\n"
-        "See the xmllib docs: https://docs.dasch.swiss/latest/DSP-TOOLS/xmllib-docs/xmlroot/"
+        "See the xmllib docs: https://docs.dasch.swiss/DSP-TOOLS/xmllib-docs/xmlroot/"
     )
     warnings.warn(DspToolsUserWarning(warn_msg))
     etree.indent(root, space="    ")

--- a/src/dsp_tools/commands/update_legal/exceptions.py
+++ b/src/dsp_tools/commands/update_legal/exceptions.py
@@ -18,6 +18,6 @@ class InvalidLicenseError(UserError):
         msg = (
             f"The provided license string is invalid and cannot be parsed: '{license_str}'"
             "You must provide a license that can be parsed by xmllib.find_license_in_string(). "
-            "See https://docs.dasch.swiss/latest/DSP-TOOLS/xmllib-docs/general-functions/#xmllib.general_functions.find_license_in_string"
+            "See https://docs.dasch.swiss/DSP-TOOLS/xmllib-docs/general-functions/#xmllib.general_functions.find_license_in_string"
         )
         super().__init__(msg)

--- a/src/dsp_tools/xmllib/general_functions.py
+++ b/src/dsp_tools/xmllib/general_functions.py
@@ -508,7 +508,7 @@ def escape_reserved_xml_characters(text: str) -> str:
     but only if they are not part of a standard standoff tag or escape sequence.
 
     [See the documentation for the standard standoff tags allowed by DSP-API,
-    which will not be escaped.](https://docs.dasch.swiss/latest/DSP-API/03-endpoints/api-v2/text/standard-standoff/)
+    which will not be escaped.](https://docs.dasch.swiss/DSP-API/03-endpoints/api-v2/text/standard-standoff/)
 
     Args:
         text: the richtext string to be escaped
@@ -745,7 +745,7 @@ def find_license_in_string(string: str) -> License | None:  # noqa: PLR0911 (too
     Look out: Your string should contain no more than 1 license.
     If it contains more, there is no guarantee which one will be returned.
 
-    See [recommended licenses](https://docs.dasch.swiss/latest/DSP-TOOLS/xmllib-docs/licenses/recommended/)
+    See [recommended licenses](https://docs.dasch.swiss/DSP-TOOLS/xmllib-docs/licenses/recommended/)
     for details.
 
     Args:

--- a/src/dsp_tools/xmllib/internal/constants.py
+++ b/src/dsp_tools/xmllib/internal/constants.py
@@ -1,4 +1,4 @@
-# The accepted XML tags are defined at https://docs.dasch.swiss/latest/DSP-API/03-endpoints/api-v2/text/standard-standoff/
+# The accepted XML tags are defined at https://docs.dasch.swiss/DSP-API/03-endpoints/api-v2/text/standard-standoff/
 _COMMON_BASE = [
     "p",
     "em",

--- a/src/dsp_tools/xmllib/models/date_formats.py
+++ b/src/dsp_tools/xmllib/models/date_formats.py
@@ -6,7 +6,7 @@ from enum import auto
 
 class DateFormat(Enum):
     """
-    Date format options for the [`reformat_date`](https://docs.dasch.swiss/latest/DSP-TOOLS/xmllib-docs/general-functions/#xmllib.general_functions.reformat_date) function.
+    Date format options for the [`reformat_date`](https://docs.dasch.swiss/DSP-TOOLS/xmllib-docs/general-functions/#xmllib.general_functions.reformat_date) function.
 
     - `YYYY_MM_DD`
     - `DD_MM_YYYY`
@@ -20,7 +20,7 @@ class DateFormat(Enum):
 
 class Calendar(Enum):
     """
-    Calendar options for the [`reformat_date`](https://docs.dasch.swiss/latest/DSP-TOOLS/xmllib-docs/general-functions/#xmllib.general_functions.reformat_date) function.
+    Calendar options for the [`reformat_date`](https://docs.dasch.swiss/DSP-TOOLS/xmllib-docs/general-functions/#xmllib.general_functions.reformat_date) function.
 
     - `GREGORIAN`
     - `JULIAN`
@@ -34,7 +34,7 @@ class Calendar(Enum):
 
 class Era(Enum):
     """
-    Era options for the [`reformat_date`](https://docs.dasch.swiss/latest/DSP-TOOLS/xmllib-docs/general-functions/#xmllib.general_functions.reformat_date) function.
+    Era options for the [`reformat_date`](https://docs.dasch.swiss/DSP-TOOLS/xmllib-docs/general-functions/#xmllib.general_functions.reformat_date) function.
 
     - `CE`
     - `BCE`

--- a/src/dsp_tools/xmllib/models/dsp_base_resources.py
+++ b/src/dsp_tools/xmllib/models/dsp_base_resources.py
@@ -54,7 +54,7 @@ class RegionResource:
         Exactly one geometry shape has to be added to the resource with one of the following methods:
         `add_rectangle`, `add_polygon`, `add_circle` (see documentation below for more information).
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#region)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#region)
 
         Args:
             res_id: ID of this region resource
@@ -109,7 +109,7 @@ class RegionResource:
         """
         Add a rectangle shape to the region.
 
-        [For a visual example see the XML documentation](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#geometry)
+        [For a visual example see the XML documentation](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#geometry)
 
         Args:
             point1: first point of the rectangle represented as two numbers between 0 and 1 in the format (x, y)
@@ -162,7 +162,7 @@ class RegionResource:
         A polygon should have at least three points.
         If you wish to create a rectangle, please use the designated `add_rectangle` method.
 
-        [For a visual example see the XML documentation](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#geometry)
+        [For a visual example see the XML documentation](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#geometry)
 
         **Please note that this cannot currently be displayed in the dsp-app.**
 
@@ -209,7 +209,7 @@ class RegionResource:
         """
         Add a circle shape to the region.
 
-        [For a visual example see the XML documentation](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#geometry)
+        [For a visual example see the XML documentation](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#geometry)
 
         **Please note that this cannot currently be displayed in the dsp-app.**
 
@@ -388,7 +388,7 @@ class LinkResource:
         Creates a new link resource.
         A link resource is like a container that groups together several other resources of different classes.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#link)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#link)
 
         Args:
             res_id: ID of this link resource
@@ -579,7 +579,7 @@ class VideoSegmentResource:
         """
         Creates a new video segment resource, i.e. a time span of a MovingImageRepresentation.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#video-segment-and-audio-segment)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#video-segment-and-audio-segment)
 
         Args:
             res_id: ID of this video segment resource
@@ -1097,7 +1097,7 @@ class AudioSegmentResource:
         """
         Creates a new audio segment resource, i.e. a time span of an AudioRepresentation.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#video-segment-and-audio-segment)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#video-segment-and-audio-segment)
 
         Args:
             res_id: ID of this audio segment resource

--- a/src/dsp_tools/xmllib/models/licenses/other.py
+++ b/src/dsp_tools/xmllib/models/licenses/other.py
@@ -6,10 +6,10 @@ from dsp_tools.xmllib.models.licenses.recommended import License
 class LicenseOther:
     """
     Pre-defined licenses that are available in DSP.
-    If the user is free to choose a license, we recommend to choose from our [recommended licenses](https://docs.dasch.swiss/latest/DSP-TOOLS/xmllib-docs/licenses/recommended/).
+    If the user is free to choose a license, we recommend to choose from our [recommended licenses](https://docs.dasch.swiss/DSP-TOOLS/xmllib-docs/licenses/recommended/).
 
-    - `Public`: [See `Public` for details](https://docs.dasch.swiss/latest/DSP-TOOLS/xmllib-docs/licenses/other/#xmllib.models.licenses.other.Public).
-    - `Various`: [See `Various` for details](https://docs.dasch.swiss/latest/DSP-TOOLS/xmllib-docs/licenses/other/#xmllib.models.licenses.other.Various).
+    - `Public`: [See `Public` for details](https://docs.dasch.swiss/DSP-TOOLS/xmllib-docs/licenses/other/#xmllib.models.licenses.other.Public).
+    - `Various`: [See `Various` for details](https://docs.dasch.swiss/DSP-TOOLS/xmllib-docs/licenses/other/#xmllib.models.licenses.other.Various).
 
     Examples:
         ```python
@@ -30,7 +30,7 @@ class LicenseOther:
 class Public(License):
     """
     Pre-defined public domain licenses.
-    [See the API documentation for details about the licenses.](https://docs.dasch.swiss/latest/DSP-API/01-introduction/legal-info/#license)
+    [See the API documentation for details about the licenses.](https://docs.dasch.swiss/DSP-API/01-introduction/legal-info/#license)
 
     - `CC_0_1_0`: CC0 1.0 Universal
     - `CC_PDM_1_0`: Public Domain Mark 1.0 Universal
@@ -43,7 +43,7 @@ class Public(License):
 class Various(License):
     """
     A collection of various, pre-defined licenses.
-    [See the API documentation for details about the licenses.](https://docs.dasch.swiss/latest/DSP-API/01-introduction/legal-info/#license)
+    [See the API documentation for details about the licenses.](https://docs.dasch.swiss/DSP-API/01-introduction/legal-info/#license)
 
     - `BORIS_STANDARD`: BORIS Standard License
     - `FRANCE_OUVERTE`: LICENCE OUVERTE 2.0

--- a/src/dsp_tools/xmllib/models/licenses/recommended.py
+++ b/src/dsp_tools/xmllib/models/licenses/recommended.py
@@ -10,11 +10,11 @@ class LicenseRecommended:
     """
     Recommended licenses:
 
-    - `DSP`: Licenses created and curated by DaSCH, [see `DSP` for details.](https://docs.dasch.swiss/latest/DSP-TOOLS/xmllib-docs/licenses/recommended/#xmllib.models.licenses.recommended.DSP)
-    - `CC`: Creative Commons licenses, [see `CC` for details.](https://docs.dasch.swiss/latest/DSP-TOOLS/xmllib-docs/licenses/recommended/#xmllib.models.licenses.recommended.CC)
+    - `DSP`: Licenses created and curated by DaSCH, [see `DSP` for details.](https://docs.dasch.swiss/DSP-TOOLS/xmllib-docs/licenses/recommended/#xmllib.models.licenses.recommended.DSP)
+    - `CC`: Creative Commons licenses, [see `CC` for details.](https://docs.dasch.swiss/DSP-TOOLS/xmllib-docs/licenses/recommended/#xmllib.models.licenses.recommended.CC)
 
     Tip:
-        Use the helper function [`find_license_in_string()`](https://docs.dasch.swiss/latest/DSP-TOOLS/xmllib-docs/general-functions/#xmllib.general_functions.find_license_in_string)
+        Use the helper function [`find_license_in_string()`](https://docs.dasch.swiss/DSP-TOOLS/xmllib-docs/general-functions/#xmllib.general_functions.find_license_in_string)
         to parse a license from a string.
 
     Examples:
@@ -55,7 +55,7 @@ class CC(License):
     - `BY_NC_ND`: [Attribution-NonCommercial-NoDerivatives 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0/)
 
     Tip:
-        Use the helper function [find_license_in_string()](https://docs.dasch.swiss/latest/DSP-TOOLS/xmllib-docs/general-functions/#xmllib.general_functions.find_license_in_string)
+        Use the helper function [find_license_in_string()](https://docs.dasch.swiss/DSP-TOOLS/xmllib-docs/general-functions/#xmllib.general_functions.find_license_in_string)
         to parse a license from a string.
 
     Examples:

--- a/src/dsp_tools/xmllib/models/res.py
+++ b/src/dsp_tools/xmllib/models/res.py
@@ -65,7 +65,7 @@ class Resource:
         Create a new resource.
 
         Tip:
-            Use the helper function [`make_xsd_compatible_id()`](https://docs.dasch.swiss/latest/DSP-TOOLS/xmllib-docs/general-functions/#xmllib.general_functions.make_xsd_compatible_id)
+            Use the helper function [`make_xsd_compatible_id()`](https://docs.dasch.swiss/DSP-TOOLS/xmllib-docs/general-functions/#xmllib.general_functions.make_xsd_compatible_id)
             to transform the resource ID into a format that meets the requirements for an XML ID.
 
         Args:
@@ -144,7 +144,7 @@ class Resource:
         """
         Add a boolean value to the resource.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#boolean)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#boolean)
 
         Conversions:
          - The conversion is case-insensitive, meaning that the words can also be capitalised.
@@ -185,7 +185,7 @@ class Resource:
         """
         If the value is not empty, add it to the resource, otherwise return the resource unchanged.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#boolean)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#boolean)
 
         Conversions:
          - The conversion is case-insensitive, meaning that the words can also be capitalised.
@@ -235,7 +235,7 @@ class Resource:
         """
         Add a color value to the resource.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#color)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#color)
 
         Args:
             prop_name: name of the property
@@ -244,7 +244,7 @@ class Resource:
             comment: optional comment
             order: Position at which this value is displayed in the app (starting at 0),
                    relative to other values of the same property.
-                   [See documentation for details.](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#value-order)
+                   [See documentation for details.](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#value-order)
 
         Returns:
             The original resource, with the added value
@@ -280,7 +280,7 @@ class Resource:
         """
         Add several color values to the resource.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#color)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#color)
 
         Args:
             prop_name: name of the property
@@ -289,7 +289,7 @@ class Resource:
             comment: optional comment
             include_value_order: If True, each value is assigned a persistent display order
                                  based on its position in the input list.
-                                 [See documentation for details.](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#value-order)
+                                 [See documentation for details.](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#value-order)
 
         Returns:
             The original resource, with the added values
@@ -322,7 +322,7 @@ class Resource:
         """
         If the value is not empty, add it to the resource, otherwise return the resource unchanged.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#color)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#color)
 
         Args:
             prop_name: name of the property
@@ -366,11 +366,11 @@ class Resource:
     ) -> Resource:
         """
         Add a date value to the resource.
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#date)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#date)
 
         Tip:
-            Use one of the helper functions [`reformat_date()`](https://docs.dasch.swiss/latest/DSP-TOOLS/xmllib-docs/general-functions/#xmllib.general_functions.reformat_date)
-            or [`find_dates_in_string()`](https://docs.dasch.swiss/latest/DSP-TOOLS/xmllib-docs/general-functions/#xmllib.general_functions.find_dates_in_string)
+            Use one of the helper functions [`reformat_date()`](https://docs.dasch.swiss/DSP-TOOLS/xmllib-docs/general-functions/#xmllib.general_functions.reformat_date)
+            or [`find_dates_in_string()`](https://docs.dasch.swiss/DSP-TOOLS/xmllib-docs/general-functions/#xmllib.general_functions.find_dates_in_string)
             to transform a date into the DSP conform format.
 
         Args:
@@ -380,7 +380,7 @@ class Resource:
             comment: optional comment
             order: Position at which this value is displayed in the app (starting at 0),
                    relative to other values of the same property.
-                   [See documentation for details.](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#value-order)
+                   [See documentation for details.](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#value-order)
 
         Returns:
             The original resource, with the added value
@@ -416,7 +416,7 @@ class Resource:
         """
         Add several date values to the resource.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#date)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#date)
 
         Args:
             prop_name: name of the property
@@ -425,7 +425,7 @@ class Resource:
             comment: optional comment
             include_value_order: If True, each value is assigned a persistent display order
                                  based on its position in the input list.
-                                 [See documentation for details.](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#value-order)
+                                 [See documentation for details.](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#value-order)
 
         Returns:
             The original resource, with the added values
@@ -458,7 +458,7 @@ class Resource:
         """
         If the value is not empty, add it to the resource, otherwise return the resource unchanged.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#date)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#date)
 
         Args:
             prop_name: name of the property
@@ -504,7 +504,7 @@ class Resource:
         Add a decimal value to the resource.
         If the value is provided as string, it must be convertible to integer or float.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#decimal)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#decimal)
 
         Args:
             prop_name: name of the property
@@ -513,7 +513,7 @@ class Resource:
             comment: optional comment
             order: Position at which this value is displayed in the app (starting at 0),
                    relative to other values of the same property.
-                   [See documentation for details.](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#value-order)
+                   [See documentation for details.](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#value-order)
 
         Returns:
             The original resource, with the added value
@@ -550,7 +550,7 @@ class Resource:
         Add several decimal values to the resource.
         If the values are provided as string, they must be convertible to integer or float.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#decimal)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#decimal)
 
         Args:
             prop_name: name of the property
@@ -559,7 +559,7 @@ class Resource:
             comment: optional comment
             include_value_order: If True, each value is assigned a persistent display order
                                  based on its position in the input list.
-                                 [See documentation for details.](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#value-order)
+                                 [See documentation for details.](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#value-order)
 
         Returns:
             The original resource, with the added values
@@ -593,7 +593,7 @@ class Resource:
         If the value is not empty, add it to the resource, otherwise return the resource unchanged.
         If the value is provided as string, it must be convertible to integer or float.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#decimal)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#decimal)
 
         Args:
             prop_name: name of the property
@@ -640,7 +640,7 @@ class Resource:
         The [geonames.org](https://www.geonames.org/) identifier must be provided as integer
         or string that is convertible to integer.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#geoname)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#geoname)
 
 
         Args:
@@ -650,7 +650,7 @@ class Resource:
             comment: optional comment
             order: Position at which this value is displayed in the app (starting at 0),
                    relative to other values of the same property.
-                   [See documentation for details.](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#value-order)
+                   [See documentation for details.](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#value-order)
 
         Returns:
             The original resource, with the added value
@@ -688,7 +688,7 @@ class Resource:
         The [geonames.org](https://www.geonames.org/) identifiers must be provided as integers
         or strings that are convertible to integers.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#geoname)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#geoname)
 
         Args:
             prop_name: name of the property
@@ -697,7 +697,7 @@ class Resource:
             comment: optional comment
             include_value_order: If True, each value is assigned a persistent display order
                                  based on its position in the input list.
-                                 [See documentation for details.](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#value-order)
+                                 [See documentation for details.](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#value-order)
 
         Returns:
             The original resource, with the added values
@@ -732,7 +732,7 @@ class Resource:
         The [geonames.org](https://www.geonames.org/) identifier must be provided as integer
         or string that is convertible to integer.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#geoname)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#geoname)
 
         Args:
             prop_name: name of the property
@@ -778,7 +778,7 @@ class Resource:
         Add an integer value to the resource.
         If the value is provided as string, it must be convertible to integer.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#integer)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#integer)
 
         Args:
             prop_name: name of the property
@@ -787,7 +787,7 @@ class Resource:
             comment: optional comment
             order: Position at which this value is displayed in the app (starting at 0),
                    relative to other values of the same property.
-                   [See documentation for details.](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#value-order)
+                   [See documentation for details.](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#value-order)
 
         Returns:
             The original resource, with the added value
@@ -824,7 +824,7 @@ class Resource:
         Add several integer values to the resource.
         If the values are provided as string, they must be convertible to integer.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#integer)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#integer)
 
         Args:
             prop_name: name of the property
@@ -833,7 +833,7 @@ class Resource:
             comment: optional comment
             include_value_order: If True, each value is assigned a persistent display order
                                  based on its position in the input list.
-                                 [See documentation for details.](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#value-order)
+                                 [See documentation for details.](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#value-order)
 
         Returns:
             The original resource, with the added values
@@ -867,7 +867,7 @@ class Resource:
         If the value is not empty, add it to the resource, otherwise return the resource unchanged.
         If the value is provided as string, it must be convertible to integer.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#integer)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#integer)
 
         Args:
             prop_name: name of the property
@@ -913,7 +913,7 @@ class Resource:
         Add a link value to the resource. The value is either the internal ID of another resource
         inside the XML, or the IRI of an already existing resource on DSP.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#resptr)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#resptr)
 
         Args:
             prop_name: name of the property
@@ -922,7 +922,7 @@ class Resource:
             comment: optional comment
             order: Position at which this value is displayed in the app (starting at 0),
                    relative to other values of the same property.
-                   [See documentation for details.](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#value-order)
+                   [See documentation for details.](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#value-order)
 
         Returns:
             The original resource, with the added value
@@ -959,7 +959,7 @@ class Resource:
         Add several link values to the resource. Each value is either the internal ID of another
         resource inside the XML, or the IRI of an already existing resource on DSP.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#resptr)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#resptr)
 
         Args:
             prop_name: name of the property
@@ -969,7 +969,7 @@ class Resource:
             comment: optional comment
             include_value_order: If True, each value is assigned a persistent display order
                                  based on its position in the input list.
-                                 [See documentation for details.](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#value-order)
+                                 [See documentation for details.](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#value-order)
 
         Returns:
             The original resource, with the added values
@@ -1004,7 +1004,7 @@ class Resource:
         If non-empty, the value must be the internal ID of another resource inside the XML,
         or the IRI of an already existing resource on DSP.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#resptr)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#resptr)
 
         Args:
             prop_name: name of the property
@@ -1051,7 +1051,7 @@ class Resource:
         Add a region-preview value to the resource. The value is either the internal ID of a Region
         inside the XML, or the IRI of an already existing Region on DSP.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#region-preview)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#region-preview)
 
         Args:
             prop_name: name of the property
@@ -1060,7 +1060,7 @@ class Resource:
             comment: optional comment
             order: Position at which this value is displayed in the app (starting at 0),
                    relative to other values of the same property.
-                   [See documentation for details.](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#value-order)
+                   [See documentation for details.](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#value-order)
 
         Returns:
             The original resource, with the added value
@@ -1097,7 +1097,7 @@ class Resource:
         Add several region-preview values to the resource. Each value is either the internal ID of a
         Region inside the XML, or the IRI of an already existing Region on DSP.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#region-preview)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#region-preview)
 
         Args:
             prop_name: name of the property
@@ -1107,7 +1107,7 @@ class Resource:
             comment: optional comment
             include_value_order: If True, each value is assigned a persistent display order
                                  based on its position in the input list.
-                                 [See documentation for details.](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#value-order)
+                                 [See documentation for details.](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#value-order)
 
         Returns:
             The original resource, with the added values
@@ -1142,7 +1142,7 @@ class Resource:
         If non-empty, the value must be the internal ID of a Region inside the XML,
         or the IRI of an already existing Region on DSP.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#region-preview)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#region-preview)
 
         Args:
             prop_name: name of the property
@@ -1188,10 +1188,10 @@ class Resource:
         """
         Add a list value to the resource, i.e. a name of a list node.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#list)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#list)
 
         Tip:
-            Use the helper [`ListLookup`](https://docs.dasch.swiss/latest/DSP-TOOLS/xmllib-docs/general-functions/#xmllib.general_functions.ListLookup)
+            Use the helper [`ListLookup`](https://docs.dasch.swiss/DSP-TOOLS/xmllib-docs/general-functions/#xmllib.general_functions.ListLookup)
             to retrieve the correct list name based on the label.
 
         Args:
@@ -1202,7 +1202,7 @@ class Resource:
             comment: optional comment
             order: Position at which this value is displayed in the app (starting at 0),
                    relative to other values of the same property.
-                   [See documentation for details.](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#value-order)
+                   [See documentation for details.](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#value-order)
 
         Returns:
             The original resource, with the added value
@@ -1241,7 +1241,7 @@ class Resource:
         """
         Add several list values to the resource, i.e. names of list nodes.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#list)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#list)
 
         Args:
             prop_name: name of the property
@@ -1251,7 +1251,7 @@ class Resource:
             comment: optional comment
             include_value_order: If True, each value is assigned a persistent display order
                                  based on its position in the input list.
-                                 [See documentation for details.](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#value-order)
+                                 [See documentation for details.](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#value-order)
 
         Returns:
             The original resource, with the added values
@@ -1286,7 +1286,7 @@ class Resource:
         """
         If the value is not empty, add it to the resource, otherwise return the resource unchanged.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#list)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#list)
 
         Args:
             prop_name: name of the property
@@ -1334,7 +1334,7 @@ class Resource:
         """
         Add a simple text value to the resource.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#text)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#text)
 
         Args:
             prop_name: name of the property
@@ -1343,7 +1343,7 @@ class Resource:
             comment: optional comment
             order: Position at which this value is displayed in the app (starting at 0),
                    relative to other values of the same property.
-                   [See documentation for details.](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#value-order)
+                   [See documentation for details.](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#value-order)
 
         Returns:
             The original resource, with the added value
@@ -1379,7 +1379,7 @@ class Resource:
         """
         Add several simple text values to the resource.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#text)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#text)
 
         Args:
             prop_name: name of the property
@@ -1388,7 +1388,7 @@ class Resource:
             comment: optional comment
             include_value_order: If True, each value is assigned a persistent display order
                                  based on its position in the input list.
-                                 [See documentation for details.](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#value-order)
+                                 [See documentation for details.](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#value-order)
 
         Returns:
             The original resource, with the added values
@@ -1421,7 +1421,7 @@ class Resource:
         """
         If the value is not empty, add it to the resource, otherwise return the resource unchanged.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#text)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#text)
 
         Args:
             prop_name: name of the property
@@ -1466,7 +1466,7 @@ class Resource:
         """
         Add a textarea value to the resource.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#text)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#text)
 
         Args:
             prop_name: name of the property
@@ -1475,7 +1475,7 @@ class Resource:
             comment: optional comment
             order: Position at which this value is displayed in the app (starting at 0),
                    relative to other values of the same property.
-                   [See documentation for details.](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#value-order)
+                   [See documentation for details.](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#value-order)
 
         Returns:
             The original resource, with the added value
@@ -1502,7 +1502,7 @@ class Resource:
         """
         Add several textarea values to the resource.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#text)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#text)
 
         Args:
             prop_name: name of the property
@@ -1511,7 +1511,7 @@ class Resource:
             comment: optional comment
             include_value_order: If True, each value is assigned a persistent display order
                                  based on its position in the input list.
-                                 [See documentation for details.](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#value-order)
+                                 [See documentation for details.](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#value-order)
 
         Returns:
             The original resource, with the added values
@@ -1537,7 +1537,7 @@ class Resource:
         """
         If the value is not empty, add it to the resource, otherwise return the resource unchanged.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#text)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#text)
 
         Args:
             prop_name: name of the property
@@ -1582,15 +1582,15 @@ class Resource:
         """
         Add a rich text value to the resource.
         Rich text values must be provided as strings, potentially containing DSP Standard Standoff Markup XML tags
-        as [documented here.](https://docs.dasch.swiss/latest/DSP-API/03-endpoints/api-v2/text/standard-standoff/)
+        as [documented here.](https://docs.dasch.swiss/DSP-API/03-endpoints/api-v2/text/standard-standoff/)
         Only the documented tags are allowed.
 
         Conversions:
             By default, replace newline characters inside the text value with `<br/>`, which preserves the linebreak.
             Without this replacement, the newline would disappear, because `\\n` is meaningless in an XML file.
-            [Click here for more details](https://docs.dasch.swiss/latest/DSP-TOOLS/xmllib-docs/value-converters/#xmllib.value_converters.replace_newlines_with_tags)
+            [Click here for more details](https://docs.dasch.swiss/DSP-TOOLS/xmllib-docs/value-converters/#xmllib.value_converters.replace_newlines_with_tags)
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#text)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#text)
 
         Args:
             prop_name: name of the property
@@ -1599,7 +1599,7 @@ class Resource:
             comment: optional comment
             order: Position at which this value is displayed in the app (starting at 0),
                    relative to other values of the same property.
-                   [See documentation for details.](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#value-order)
+                   [See documentation for details.](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#value-order)
             newline_replacement: options how to deal with `\\n` inside the text value. Default: replace with `<br/>`
 
         Returns:
@@ -1647,15 +1647,15 @@ class Resource:
         """
         Add several rich text values to the resource.
         Rich text values must be provided as strings, potentially containing DSP Standard Standoff Markup XML tags
-        as [documented here.](https://docs.dasch.swiss/latest/DSP-API/03-endpoints/api-v2/text/standard-standoff/)
+        as [documented here.](https://docs.dasch.swiss/DSP-API/03-endpoints/api-v2/text/standard-standoff/)
         Only the documented tags are allowed.
 
         Conversions:
             By default, replace newline characters inside the text value with `<br/>`, which preserves the linebreak.
             Without this replacement, the newline would disappear, because `\\n` is meaningless in an XML file.
-            [Click here for more details](https://docs.dasch.swiss/latest/DSP-TOOLS/xmllib-docs/value-converters/#xmllib.value_converters.replace_newlines_with_tags)
+            [Click here for more details](https://docs.dasch.swiss/DSP-TOOLS/xmllib-docs/value-converters/#xmllib.value_converters.replace_newlines_with_tags)
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#text)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#text)
 
         Args:
             prop_name: name of the property
@@ -1664,7 +1664,7 @@ class Resource:
             comment: optional comment
             include_value_order: If True, each value is assigned a persistent display order
                                  based on its position in the input list.
-                                 [See documentation for details.](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#value-order)
+                                 [See documentation for details.](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#value-order)
             newline_replacement: options how to deal with `\\n` inside the text value. Default: replace with `<br/>`
 
         Returns:
@@ -1712,15 +1712,15 @@ class Resource:
         """
         If the value is not empty, add it to the resource, otherwise return the resource unchanged.
         Rich text values must be provided as strings, potentially containing DSP Standard Standoff Markup XML tags
-        as [documented here.](https://docs.dasch.swiss/latest/DSP-API/03-endpoints/api-v2/text/standard-standoff/)
+        as [documented here.](https://docs.dasch.swiss/DSP-API/03-endpoints/api-v2/text/standard-standoff/)
         Only the documented tags are allowed.
 
         Conversions:
             By default, replace newline characters inside the text value with `<br/>`, which preserves the linebreak.
             Without this replacement, the newline would disappear, because `\\n` is meaningless in an XML file.
-            [Click here for more details](https://docs.dasch.swiss/latest/DSP-TOOLS/xmllib-docs/value-converters/#xmllib.value_converters.replace_newlines_with_tags)
+            [Click here for more details](https://docs.dasch.swiss/DSP-TOOLS/xmllib-docs/value-converters/#xmllib.value_converters.replace_newlines_with_tags)
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#text)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#text)
 
         Args:
             prop_name: name of the property
@@ -1729,7 +1729,7 @@ class Resource:
             comment: optional comment
             order: Position at which this value is displayed in the app (starting at 0),
                    relative to other values of the same property.
-                   [See documentation for details.](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#value-order)
+                   [See documentation for details.](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#value-order)
             newline_replacement: options how to deal with `\\n` inside the text value. Default: replace with `<br/>`
 
         Returns:
@@ -1769,7 +1769,7 @@ class Resource:
         """
         Add a time value to the resource.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#time)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#time)
 
         Args:
             prop_name: name of the property
@@ -1778,7 +1778,7 @@ class Resource:
             comment: optional comment
             order: Position at which this value is displayed in the app (starting at 0),
                    relative to other values of the same property.
-                   [See documentation for details.](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#value-order)
+                   [See documentation for details.](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#value-order)
 
         Returns:
             The original resource, with the added value
@@ -1814,7 +1814,7 @@ class Resource:
         """
         Add several time values to the resource.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#time)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#time)
 
         Args:
             prop_name: name of the property
@@ -1823,7 +1823,7 @@ class Resource:
             comment: optional comment
             include_value_order: If True, each value is assigned a persistent display order
                                  based on its position in the input list.
-                                 [See documentation for details.](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#value-order)
+                                 [See documentation for details.](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#value-order)
 
         Returns:
             The original resource, with the added values
@@ -1856,7 +1856,7 @@ class Resource:
         """
         If the value is not empty, add it to the resource, otherwise return the resource unchanged.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#time)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#time)
 
         Args:
             prop_name: name of the property
@@ -1901,7 +1901,7 @@ class Resource:
         """
         Add a URI value to the resource.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#uri)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#uri)
 
         Args:
             prop_name: name of the property
@@ -1910,7 +1910,7 @@ class Resource:
             comment: optional comment
             order: Position at which this value is displayed in the app (starting at 0),
                    relative to other values of the same property.
-                   [See documentation for details.](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#value-order)
+                   [See documentation for details.](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#value-order)
 
         Returns:
             The original resource, with the added value
@@ -1946,7 +1946,7 @@ class Resource:
         """
         Add several URI values to the resource.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#uri)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#uri)
 
         Args:
             prop_name: name of the property
@@ -1955,7 +1955,7 @@ class Resource:
             comment: optional comment
             include_value_order: If True, each value is assigned a persistent display order
                                  based on its position in the input list.
-                                 [See documentation for details.](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#value-order)
+                                 [See documentation for details.](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#value-order)
 
         Returns:
             The original resource, with the added values
@@ -1988,7 +1988,7 @@ class Resource:
         """
         If the value is not empty, add it to the resource, otherwise return the resource unchanged.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#uri)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#uri)
 
         Args:
             prop_name: name of the property
@@ -2034,11 +2034,11 @@ class Resource:
         """
         Add a file (bitstream) to the resource.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#bitstream)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#bitstream)
 
         Args:
             filename: path to the file
-            license: License of the file (predefined or custom) [see the documentation for the options.](https://docs.dasch.swiss/latest/DSP-TOOLS/xmllib-docs/licenses/recommended/).
+            license: License of the file (predefined or custom) [see the documentation for the options.](https://docs.dasch.swiss/DSP-TOOLS/xmllib-docs/licenses/recommended/).
                 A license states the circumstances how you are allowed to share/reuse something.
             copyright_holder: The person or institution who owns the economic rights of something.
             authorship: The (natural) person who authored something.
@@ -2112,11 +2112,11 @@ class Resource:
         """
         Add a IIIF URI to the resource.
 
-        [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#iiif-uri)
+        [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#iiif-uri)
 
         Args:
             iiif_uri: valid IIIF URI
-            license: License of the file (predefined or custom) [see the documentation for the options.](https://docs.dasch.swiss/latest/DSP-TOOLS/xmllib-docs/licenses/recommended/).
+            license: License of the file (predefined or custom) [see the documentation for the options.](https://docs.dasch.swiss/DSP-TOOLS/xmllib-docs/licenses/recommended/).
                 A license states the circumstances how you are allowed to share/reuse something.
             copyright_holder: The person or institution who owns the economic rights of something.
             authorship: The (natural) person who authored something.

--- a/src/dsp_tools/xmllib/value_checkers.py
+++ b/src/dsp_tools/xmllib/value_checkers.py
@@ -421,7 +421,7 @@ def check_richtext_syntax(richtext: str) -> None:
     Then, it tries to parse the resulting XML.
 
     Note: Only DSP standard standoff tags are allowed in richtexts. They are documented
-    [here](https://docs.dasch.swiss/latest/DSP-API/03-endpoints/api-v2/text/standard-standoff/).
+    [here](https://docs.dasch.swiss/DSP-API/03-endpoints/api-v2/text/standard-standoff/).
 
     Args:
         richtext: richtext to check

--- a/src/dsp_tools/xmllib/value_converters.py
+++ b/src/dsp_tools/xmllib/value_converters.py
@@ -179,9 +179,9 @@ def reformat_date(
         date: date string to be reformatted
         date_precision_separator: the separation between the day, month and year
         date_range_separator: the separation between two dates
-        date_format: the format of the date, see [`DateFormat` for options](https://docs.dasch.swiss/latest/DSP-TOOLS/xmllib-docs/date_formats/#xmllib.models.date_formats.DateFormat)
-        calendar: the calendar of the date, see [`Calendar` for options](https://docs.dasch.swiss/latest/DSP-TOOLS/xmllib-docs/date_formats/#xmllib.models.date_formats.Calendar)
-        era: the era of the date, see [`Era` for options](https://docs.dasch.swiss/latest/DSP-TOOLS/xmllib-docs/date_formats/#xmllib.models.date_formats.Era)
+        date_format: the format of the date, see [`DateFormat` for options](https://docs.dasch.swiss/DSP-TOOLS/xmllib-docs/date_formats/#xmllib.models.date_formats.DateFormat)
+        calendar: the calendar of the date, see [`Calendar` for options](https://docs.dasch.swiss/DSP-TOOLS/xmllib-docs/date_formats/#xmllib.models.date_formats.Calendar)
+        era: the era of the date, see [`Era` for options](https://docs.dasch.swiss/DSP-TOOLS/xmllib-docs/date_formats/#xmllib.models.date_formats.Era)
         resource_id: the ID of the associated resource, this is to improve the error message
 
     Returns:
@@ -363,7 +363,7 @@ def find_dates_in_string(string: str) -> set[str]:
     Checks if a string contains date values (single dates, or date ranges),
     and return all found dates as set of DSP-formatted strings.
     Returns an empty set if no date was found.
-    [See XML documentation for details](https://docs.dasch.swiss/latest/DSP-TOOLS/data-file/xml-data-file/#date).
+    [See XML documentation for details](https://docs.dasch.swiss/DSP-TOOLS/data-file/xml-data-file/#date).
 
     Notes:
         - If no era or calendar is given, dates are interpreted in the Common Era and the Gregorian calendar.


### PR DESCRIPTION
## Summary

- `docs.dasch.swiss` dropped its versioned `mike`-based site for a single flat, unversioned site (DEV-6903). `/latest/...` and dated-version URLs still resolve via a permanent compat shim, but new references dsp-tools emits should point at the flat path going forward.
- Replaces every `docs.dasch.swiss/latest/...` link with the flat `docs.dasch.swiss/...` equivalent across the 20 files identified in [DEV-6966](https://linear.app/dasch/issue/DEV-6966/stop-emitting-docsdaschswisslatest-links-from-dsp-tools): 11 files under `src/dsp_tools/`, `mkdocs.yml`, `pyproject.toml`, `README.md`, and 6 docs pages.
- Also fixes one link the ticket's file list didn't call out: `src/dsp_tools/commands/excel2xml/excel2xml_lib.py` had a leftover dated `mike` version tag (`docs.dasch.swiss/2023.12.01/...`) instead of `latest` — same dead-versioned-path problem, same fix.
- Updates `_categorize_url()` in `scripts/validate_xmllib_docstring_links.py` to match the flat `docs.dasch.swiss/DSP-TOOLS/` path instead of the old `/latest/DSP-TOOLS/` pattern, so the validator keeps recognizing internal docs links correctly.
- Only URL segments were changed — unrelated surrounding prose (e.g. README's description of the docs deployment process) was left as-is.

## Test plan

- [x] `grep -rn "docs.dasch.swiss/latest"` and a broader path-segment search confirm no `/latest` or stale dated-version links remain anywhere in the repo
- [x] `python scripts/validate_xmllib_docstring_links.py` reports all xmllib docstring links valid
- [x] `just ruff-check`, `just mypy`, `just yamllint`, `just markdownlint` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)